### PR TITLE
feat: scaffold 0.0.1 foundation (monorepo, SAM stack, health API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+infra/dist/
+.aws-sam/
+*.log
+.DS_Store
+.env
+.env.*
+.envrc
+

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,38 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "thatblog",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "prettier": "^3.3.0",
+        "typescript": "^5.6.0",
+      },
+    },
+    "components/backend-api": {
+      "name": "@thatblog/backend-api",
+      "version": "0.0.1",
+      "dependencies": {
+        "hono": "^4.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@thatblog/backend-api": ["@thatblog/backend-api@workspace:components/backend-api"],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "hono": ["hono@4.12.29", "", {}, "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/components/backend-api/app.ts
+++ b/components/backend-api/app.ts
@@ -1,0 +1,13 @@
+import { Hono } from 'hono';
+
+export const app = new Hono();
+
+app.get('/health', (c) =>
+  c.json({
+    status: 'ok',
+    service: 'backend-api',
+    version: '0.0.1',
+  }),
+);
+
+export default app;

--- a/components/backend-api/lambda.ts
+++ b/components/backend-api/lambda.ts
@@ -1,0 +1,4 @@
+import { handle } from 'hono/aws-lambda';
+import { app } from './app';
+
+export const handler = handle(app);

--- a/components/backend-api/package.json
+++ b/components/backend-api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@thatblog/backend-api",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "lambda.ts",
+  "dependencies": {
+    "hono": "^4.6.0"
+  }
+}

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build the Lambdas, deploy the SAM stack, then health-check the deployed API.
+# Usage: infra/deploy.sh [stack-name]   (default: thatblog)
+set -euo pipefail
+
+STACK_NAME="${1:-thatblog}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the region once and pass it to both sam and aws, so they can never
+# target different regions (e.g. sam using the config default while aws uses env).
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || true)}}"
+if [[ -z "$REGION" ]]; then
+  echo "ERROR: no region set. Export AWS_REGION or set a default with 'aws configure'." >&2
+  exit 1
+fi
+echo "==> Region: $REGION"
+
+echo "==> Installing dependencies"
+(cd "$ROOT" && bun install)
+
+echo "==> Building backend-api"
+(cd "$ROOT" && bun run build:api)
+
+echo "==> Deploying stack: $STACK_NAME"
+sam deploy \
+  --template-file "$ROOT/infra/template.yaml" \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --resolve-s3 \
+  --capabilities CAPABILITY_IAM \
+  --no-fail-on-empty-changeset
+
+echo "==> Reading stack outputs"
+API_URL="$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+  --output text)"
+
+echo "==> Health check: ${API_URL}/health"
+curl -fsS "${API_URL}/health"
+echo
+echo "==> Deployed. API: ${API_URL}"

--- a/infra/teardown.sh
+++ b/infra/teardown.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Tear down the SAM stack. Empties the content bucket first (CloudFormation
+# cannot delete a non-empty bucket), then deletes the stack.
+# Usage: infra/teardown.sh [stack-name] [-y]   (default stack: thatblog)
+#   -y / FORCE=1  skip the confirmation prompt
+set -euo pipefail
+
+STACK_NAME="thatblog"
+FORCE="${FORCE:-0}"
+for arg in "$@"; do
+  case "$arg" in
+    -y | --yes) FORCE=1 ;;
+    *) STACK_NAME="$arg" ;;
+  esac
+done
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || true)}}"
+if [[ -z "$REGION" ]]; then
+  echo "ERROR: no region set. Export AWS_REGION or set a default with 'aws configure'." >&2
+  exit 1
+fi
+
+echo "==> Region: $REGION"
+echo "==> Stack:  $STACK_NAME"
+
+if [[ "$FORCE" != "1" ]]; then
+  read -r -p "This permanently deletes the stack and ALL its data. Type the stack name to confirm: " reply
+  if [[ "$reply" != "$STACK_NAME" ]]; then
+    echo "Aborted." >&2
+    exit 1
+  fi
+fi
+
+# Empty the content bucket so CloudFormation can delete it.
+BUCKET="$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='ContentBucketName'].OutputValue" \
+  --output text 2>/dev/null || true)"
+
+if [[ -n "$BUCKET" && "$BUCKET" != "None" ]]; then
+  echo "==> Emptying content bucket: $BUCKET"
+  aws s3 rm "s3://$BUCKET" --recursive --region "$REGION" || true
+else
+  echo "==> No content bucket found (already gone?), skipping empty"
+fi
+
+echo "==> Deleting stack: $STACK_NAME"
+sam delete \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --no-prompts
+
+echo "==> Torn down: $STACK_NAME"

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -81,7 +81,7 @@ Resources:
   ContentBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub '${AWS::StackName}-content-${AWS::AccountId}'
+      BucketName: !Sub '${AWS::StackName}-${AWS::Region}-${AWS::AccountId}'
       PublicAccessBlockConfiguration:
         BlockPublicAcls: false
         BlockPublicPolicy: false

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -1,0 +1,152 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: thatblog - multi-tenant serverless blog platform (0.0.1 foundation)
+
+Globals:
+  Function:
+    Runtime: nodejs24.x
+    Architectures:
+      - arm64
+    MemorySize: 256
+    Timeout: 10
+    Environment:
+      Variables:
+        TABLE_NAME: !Ref Table
+        CONTENT_BUCKET: !Ref ContentBucket
+
+Resources:
+  # Single multi-tenant table. Fixed key/index topology (plan section 8.1):
+  # pk/sk + 5 LSIs (ls1sk..ls5sk, fixed at creation) + gs1 (gs1pk/gs1sk).
+  # Every index projects KEYS_ONLY to keep it lean. ls4/ls5 are reserved-unused in v1.
+  Table:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${AWS::StackName}-table'
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - { AttributeName: pk, AttributeType: S }
+        - { AttributeName: sk, AttributeType: S }
+        - { AttributeName: ls1sk, AttributeType: S }
+        - { AttributeName: ls2sk, AttributeType: S }
+        - { AttributeName: ls3sk, AttributeType: S }
+        - { AttributeName: ls4sk, AttributeType: S }
+        - { AttributeName: ls5sk, AttributeType: S }
+        - { AttributeName: gs1pk, AttributeType: S }
+        - { AttributeName: gs1sk, AttributeType: S }
+      KeySchema:
+        - { AttributeName: pk, KeyType: HASH }
+        - { AttributeName: sk, KeyType: RANGE }
+      LocalSecondaryIndexes:
+        - IndexName: ls1
+          KeySchema:
+            - { AttributeName: pk, KeyType: HASH }
+            - { AttributeName: ls1sk, KeyType: RANGE }
+          Projection: { ProjectionType: KEYS_ONLY }
+        - IndexName: ls2
+          KeySchema:
+            - { AttributeName: pk, KeyType: HASH }
+            - { AttributeName: ls2sk, KeyType: RANGE }
+          Projection: { ProjectionType: KEYS_ONLY }
+        - IndexName: ls3
+          KeySchema:
+            - { AttributeName: pk, KeyType: HASH }
+            - { AttributeName: ls3sk, KeyType: RANGE }
+          Projection: { ProjectionType: KEYS_ONLY }
+        - IndexName: ls4
+          KeySchema:
+            - { AttributeName: pk, KeyType: HASH }
+            - { AttributeName: ls4sk, KeyType: RANGE }
+          Projection: { ProjectionType: KEYS_ONLY }
+        - IndexName: ls5
+          KeySchema:
+            - { AttributeName: pk, KeyType: HASH }
+            - { AttributeName: ls5sk, KeyType: RANGE }
+          Projection: { ProjectionType: KEYS_ONLY }
+      GlobalSecondaryIndexes:
+        - IndexName: gs1
+          KeySchema:
+            - { AttributeName: gs1pk, KeyType: HASH }
+            - { AttributeName: gs1sk, KeyType: RANGE }
+          Projection: { ProjectionType: KEYS_ONLY }
+      # UserSession TTL (plan 10.1); harmless before the entity exists.
+      TimeToLiveSpecification:
+        AttributeName: expiresAt
+        Enabled: true
+      SSESpecification:
+        SSEEnabled: true
+
+  # Per-stack content bucket: themes/{blogId}/ + uploads/{blogId}/ + admin/ (plan #7, #14, #17).
+  # Public static-website endpoint so the /admin S3 proxy needs no SigV4, and index.html as the
+  # error document gives client-side-routing fallback for free.
+  ContentBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub '${AWS::StackName}-content-${AWS::AccountId}'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: index.html
+
+  ContentBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ContentBucket
+      PolicyDocument:
+        Statement:
+          - Sid: PublicReadGetObject
+            Effect: Allow
+            Principal: '*'
+            Action: s3:GetObject
+            Resource: !Sub '${ContentBucket.Arn}/*'
+
+  # Single HTTP API front door (plan #2). $default stage = no stage suffix on the URL.
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: $default
+
+  BackendApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-backend-api'
+      CodeUri: dist/backend-api
+      Handler: lambda.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref Table
+        - S3CrudPolicy:
+            BucketName: !Ref ContentBucket
+      Events:
+        Root:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /
+            Method: ANY
+        Proxy:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /{proxy+}
+            Method: ANY
+
+Outputs:
+  ApiUrl:
+    Description: HTTP API base URL
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com'
+  TableName:
+    Description: DynamoDB table name
+    Value: !Ref Table
+  ContentBucketName:
+    Description: Content bucket name (deploy script syncs assets here)
+    Value: !Ref ContentBucket
+  ContentBucketWebsiteUrl:
+    Description: Content bucket static-website endpoint
+    Value: !GetAtt ContentBucket.WebsiteURL

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+# Toolchain for thatblog. Run `mise install` to provision everything.
+[tools]
+# Node 24 matches the nodejs24.x Lambda runtime (plan decision #5).
+node = "24"
+bun = "latest"
+awscli = "latest"
+aws-sam-cli = "latest"
+
+[env]
+# Local secrets (AWS credentials, etc.) — gitignored, populated per-machine.
+_.file = ".env"
+
+[tasks.deploy]
+description = "Build the Lambdas, deploy the SAM stack, then health-check the API"
+run = "infra/deploy.sh"

--- a/mise.toml
+++ b/mise.toml
@@ -13,3 +13,7 @@ _.file = ".env"
 [tasks.deploy]
 description = "Build the Lambdas, deploy the SAM stack, then health-check the API"
 run = "infra/deploy.sh"
+
+[tasks.teardown]
+description = "Empty the content bucket and delete the SAM stack"
+run = "infra/teardown.sh"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "thatblog",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "workspaces": ["components/*", "packages/*", "themes/*"],
+  "scripts": {
+    "build:api": "bun build ./components/backend-api/lambda.ts --target=node --format=cjs --outdir=infra/dist/backend-api --sourcemap=linked",
+    "build": "bun run build:api",
+    "typecheck": "tsc --noEmit",
+    "deploy": "infra/deploy.sh"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "prettier": "^3.3.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "types": ["bun"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["components/**/*.ts", "packages/**/*.ts"]
+}


### PR DESCRIPTION
## What

Lands the `0.0.1` Foundation increment from the roadmap — the deployable spine, no domain models yet.

- **Monorepo + toolchain**: Bun workspaces across `components/`, `packages/`, `themes/`; `mise.toml` pins node 24, bun, awscli and aws-sam-cli, plus `mise run deploy` / `mise run teardown` tasks.
- **Infra (SAM)**: single multi-tenant DynamoDB table with the full fixed key/index topology (`pk`/`sk`, all 5 LSIs `ls1sk`–`ls5sk`, `gs1`, every index `KEYS_ONLY`), a public static-website content bucket, an HTTP API front door, and the `backend-api` Lambda on `nodejs24.x`/arm64.
- **backend-api**: minimal Hono app exposing `GET /health`, wired to Lambda via the `hono/aws-lambda` adapter.
- **Deploy/teardown scripts**: `infra/deploy.sh` builds, deploys, and health-checks; `infra/teardown.sh` empties the content bucket (CloudFormation won't delete a non-empty bucket) then deletes the stack. Region is resolved once and passed to both `sam` and `aws` so they can never diverge.

## Why

First working, deployable slice of the platform. Establishes the structural pieces that later increments build on — the LSIs in particular are fixed at table creation, so the full topology is defined up front (per plan section 8.1) even though v1 only uses some of it.

## How to test

```bash
mise install
mise run deploy        # build -> sam deploy -> health check
mise run teardown      # empty bucket -> sam delete
```

Deployed and verified in `us-east-1`; `GET /health` returns `200 {"status":"ok","service":"backend-api","version":"0.0.1"}`. `sam validate --lint` and `tsc --noEmit` both pass. No automated test suite yet — Vitest + Testcontainers land in `0.0.2`.

## Notes

- Running the deploy creates real billable AWS resources (DynamoDB table, S3 bucket, Lambda, HTTP API).
- Region is sourced from the gitignored `.env` and resolved dynamically by the scripts; keep `AWS_REGION` consistent to avoid spawning a duplicate stack in another region.