### PR TITLE
feat: v0.0.3 setup-key first-run + email/password auth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,12 +15,15 @@
     },
     "components/backend-api": {
       "name": "@thatblog/backend-api",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.700.0",
+        "bcryptjs": "^3.0.0",
+        "dataloader": "^2.2.0",
         "electrodb": "^3.9.0",
         "hono": "^4.6.0",
         "nanoid": "^5.0.0",
+        "zod": "^4.0.0",
       },
     },
   },
@@ -285,6 +288,8 @@
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
+
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
@@ -326,6 +331,8 @@
     "crc32-stream": ["crc32-stream@6.0.0", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "dataloader": ["dataloader@2.2.3", "", {}, "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -574,6 +581,8 @@
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 

--- a/components/backend-api/app.spec.ts
+++ b/components/backend-api/app.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { testModels } from '../../test/dynamo';
+import { createApp } from './app';
+import { ensureSystem } from './auth/system';
+
+// One app bound to the Testcontainers table. This spec is the only one that touches the System
+// singleton / runs setup, so the shared table stays conflict-free across files.
+const models = testModels();
+const app = createApp(models);
+
+const json = (body: unknown) => ({
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+// The one cookie in Set-Cookie, as a `name=value` pair ready to send back as a Cookie header.
+const cookieFrom = (res: Response): string => (res.headers.get('set-cookie') ?? '').split(';')[0] ?? '';
+
+const login = (email: string, password: string) => app.request('/auth/login', json({ email, password }));
+
+describe('backend-api auth flow', () => {
+  const creds = {
+    email: 'Owner@Example.com',
+    password: 'correct horse battery',
+    displayName: 'The Owner',
+    blog: { name: 'My Blog', host: 'Blog.Example.com' },
+  };
+  let setupCookie = '';
+
+  it('completes first-run setup, normalising email/host and auto-logging in', async () => {
+    const system = await ensureSystem(models);
+    expect(system.setupKey).toBeTruthy();
+
+    const res = await app.request(`/admin/setup/${system.setupKey}`, json(creds));
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { user: { email: string }; blog: { blogId: string } };
+    expect(body.user.email).toBe('owner@example.com'); // normalised
+    expect(body.blog.blogId).toMatch(/^b/);
+
+    setupCookie = cookieFrom(res);
+    expect(setupCookie).toContain('thatblog_session=');
+  });
+
+  it('serves the authenticated user from the setup auto-login cookie', async () => {
+    const res = await app.request('/auth/me', { headers: { cookie: setupCookie } });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { user: { email: string } }).user.email).toBe('owner@example.com');
+  });
+
+  it('rejects a wrong setup key with 404, then 410 once the key is cleared', async () => {
+    // Key is already cleared by the successful setup above, so every call is now 410.
+    const res = await app.request('/admin/setup/whatever', json({}));
+    expect(res.status).toBe(410);
+  });
+
+  it('rejects login with a wrong password (generic 401)', async () => {
+    const res = await login(creds.email, 'nope');
+    expect(res.status).toBe(401);
+  });
+
+  it('logs in case-insensitively and round-trips /auth/me', async () => {
+    const res = await login('OWNER@EXAMPLE.COM', creds.password);
+    expect(res.status).toBe(200);
+
+    const me = await app.request('/auth/me', { headers: { cookie: cookieFrom(res) } });
+    expect(me.status).toBe(200);
+  });
+
+  it('rejects /auth/me without a cookie', async () => {
+    const res = await app.request('/auth/me');
+    expect(res.status).toBe(401);
+  });
+
+  it('revokes the session on logout', async () => {
+    const cookie = cookieFrom(await login(creds.email, creds.password));
+
+    const out = await app.request('/auth/logout', { method: 'POST', headers: { cookie } });
+    expect(out.status).toBe(200);
+
+    const me = await app.request('/auth/me', { headers: { cookie } });
+    expect(me.status).toBe(401); // session record deleted
+  });
+});

--- a/components/backend-api/app.ts
+++ b/components/backend-api/app.ts
@@ -1,13 +1,36 @@
 import { Hono } from 'hono';
+import { client, makeModels, TABLE_NAME, type Models } from './models';
+import { makeLoaders } from './loaders';
+import type { AppEnv } from './context';
+import { setupRoutes } from './routes/setup';
+import { authRoutes } from './routes/auth';
 
-export const app = new Hono();
+// createApp takes the model set so tests can point the whole app at a Testcontainers table (mirrors
+// makeModels); the default export binds the env-driven singletons for the Lambda.
+export function createApp(models: Models) {
+  const app = new Hono<AppEnv>();
 
-app.get('/health', (c) =>
-  c.json({
-    status: 'ok',
-    service: 'backend-api',
-    version: '0.0.2',
-  }),
-);
+  // Per-request context: shared models + fresh per-request loaders (request-scoped dedupe only).
+  app.use('*', async (c, next) => {
+    c.set('models', models);
+    c.set('loaders', makeLoaders(models));
+    await next();
+  });
+
+  app.get('/health', (c) =>
+    c.json({
+      status: 'ok',
+      service: 'backend-api',
+      version: '0.0.3',
+    }),
+  );
+
+  app.route('/', setupRoutes);
+  app.route('/', authRoutes);
+
+  return app;
+}
+
+export const app = createApp(makeModels(client, TABLE_NAME));
 
 export default app;

--- a/components/backend-api/auth/cookies.spec.ts
+++ b/components/backend-api/auth/cookies.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { signSession, verifySession } from './cookies';
+
+describe('session cookie', () => {
+  const secrets = ['newest-secret', 'older-secret'];
+
+  it('round-trips a signed session with the newest secret', () => {
+    const cookie = signSession('user-1', 'session-1', secrets);
+    expect(verifySession(cookie, secrets)).toEqual({ userId: 'user-1', sessionId: 'session-1' });
+  });
+
+  it('verifies against any secret in the list (rotation)', () => {
+    // Signed while 'older-secret' was newest; still valid once a new secret is prepended.
+    const cookie = signSession('user-1', 'session-1', ['older-secret']);
+    expect(verifySession(cookie, secrets)).toEqual({ userId: 'user-1', sessionId: 'session-1' });
+  });
+
+  it('rejects a cookie signed with an unknown/retired secret', () => {
+    const cookie = signSession('user-1', 'session-1', ['retired-secret']);
+    expect(verifySession(cookie, secrets)).toBeUndefined();
+  });
+
+  it('rejects a tampered payload', () => {
+    const cookie = signSession('user-1', 'session-1', secrets);
+    const [, sessionId, sig] = cookie.split('.');
+    expect(verifySession(`attacker.${sessionId}.${sig}`, secrets)).toBeUndefined();
+  });
+
+  it('rejects a malformed cookie', () => {
+    expect(verifySession('nope', secrets)).toBeUndefined();
+    expect(verifySession('a.b.c.d', secrets)).toBeUndefined();
+  });
+});

--- a/components/backend-api/auth/cookies.ts
+++ b/components/backend-api/auth/cookies.ts
@@ -1,0 +1,31 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+// The signed session cookie (PLAN.md 10.1): value is `userId.sessionId.signature`, HMAC-SHA256 over
+// the `userId.sessionId` payload. userId/sessionId are nanoids (alphabet has no '.'), so the parts
+// split unambiguously. We sign with the newest secret (index 0) and verify against every secret in
+// the System list, so rotation is add-new / retire-old with no forced logouts.
+export const SESSION_COOKIE = 'thatblog_session';
+
+const hmac = (payload: string, secret: string): Buffer => createHmac('sha256', secret).update(payload).digest();
+
+export function signSession(userId: string, sessionId: string, secrets: string[]): string {
+  const secret = secrets[0];
+  if (!secret) throw new Error('cannot sign session: no session secrets configured');
+  const payload = `${userId}.${sessionId}`;
+  return `${payload}.${hmac(payload, secret).toString('base64url')}`;
+}
+
+export function verifySession(cookie: string, secrets: string[]): { userId: string; sessionId: string } | undefined {
+  const parts = cookie.split('.');
+  if (parts.length !== 3) return undefined;
+  const [userId, sessionId, signature] = parts as [string, string, string];
+  const payload = `${userId}.${sessionId}`;
+  const given = Buffer.from(signature, 'base64url');
+
+  const ok = secrets.some((secret) => {
+    const expected = hmac(payload, secret);
+    return expected.length === given.length && timingSafeEqual(expected, given);
+  });
+
+  return ok ? { userId, sessionId } : undefined;
+}

--- a/components/backend-api/auth/http.ts
+++ b/components/backend-api/auth/http.ts
@@ -1,0 +1,29 @@
+import type { Context } from 'hono';
+import { deleteCookie, setCookie } from 'hono/cookie';
+import type { AppEnv } from '../context';
+import type { Models } from '../models';
+import { SESSION_COOKIE, signSession } from './cookies';
+import { createSession, SESSION_TTL_SECONDS } from './sessions';
+
+// httpOnly + Secure + SameSite=Lax signed cookie (PLAN.md 10.1). maxAge matches the session TTL so the
+// browser drops the cookie as the DynamoDB record expires. Shared by setup (auto-login) and login.
+export async function issueSession(
+  c: Context<AppEnv>,
+  models: Models,
+  secrets: string[],
+  userId: string,
+): Promise<void> {
+  const session = await createSession(models, userId);
+  const cookie = signSession(userId, session.sessionId, secrets);
+  setCookie(c, SESSION_COOKIE, cookie, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'Lax',
+    path: '/',
+    maxAge: SESSION_TTL_SECONDS,
+  });
+}
+
+export function clearSessionCookie(c: Context<AppEnv>): void {
+  deleteCookie(c, SESSION_COOKIE, { path: '/' });
+}

--- a/components/backend-api/auth/middleware.ts
+++ b/components/backend-api/auth/middleware.ts
@@ -1,0 +1,26 @@
+import type { MiddlewareHandler } from 'hono';
+import { getCookie } from 'hono/cookie';
+import type { AppEnv } from '../context';
+import { SESSION_COOKIE, verifySession } from './cookies';
+import { ensureSystem } from './system';
+import { loadSession } from './sessions';
+
+// Gate for protected routes (PLAN.md 10.1): verify the cookie signature against the System secrets,
+// look up the live session, then attach the user + session to the request. Any failure is a flat 401
+// — we don't distinguish missing / malformed / expired to a caller. Per-blog role checks
+// (MapBlogUser) layer on top of this in later milestones once a target blog is resolved.
+export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const raw = getCookie(c, SESSION_COOKIE);
+  if (!raw) return c.json({ error: 'unauthorized' }, 401);
+
+  const system = await ensureSystem(c.var.models);
+  const ref = verifySession(raw, system.sessionSecrets);
+  if (!ref) return c.json({ error: 'unauthorized' }, 401);
+
+  const loaded = await loadSession(c.var.models, ref);
+  if (!loaded) return c.json({ error: 'unauthorized' }, 401);
+
+  c.set('user', loaded.user);
+  c.set('session', loaded.session);
+  await next();
+};

--- a/components/backend-api/auth/passwords.ts
+++ b/components/backend-api/auth/passwords.ts
@@ -1,0 +1,9 @@
+import bcrypt from 'bcryptjs';
+
+// bcryptjs is pure JS (no native build), so it runs unchanged in Lambda (PLAN.md 7, 10.1). Cost 10
+// is the common default: strong enough today, well under the API Gateway timeout on login.
+const COST = 10;
+
+export const hashPassword = (plain: string): Promise<string> => bcrypt.hash(plain, COST);
+
+export const verifyPassword = (plain: string, hash: string): Promise<boolean> => bcrypt.compare(plain, hash);

--- a/components/backend-api/auth/sessions.ts
+++ b/components/backend-api/auth/sessions.ts
@@ -1,0 +1,39 @@
+import type { EntityItem } from 'electrodb';
+import type { Models } from '../models';
+import type { UserEntity } from '../models/user';
+import type { UserSessionEntity } from '../models/user-session';
+import { newSessionId } from '../models/ids';
+
+type UserItem = EntityItem<UserEntity>;
+type SessionItem = EntityItem<UserSessionEntity>;
+
+// 3-day expiry (PLAN.md 10.1), matched by the DynamoDB TTL on expiresAt so records self-clean.
+export const SESSION_TTL_SECONDS = 3 * 24 * 60 * 60;
+
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+export async function createSession(models: Models, userId: string): Promise<SessionItem> {
+  const sessionId = newSessionId();
+  const expiresAt = nowSeconds() + SESSION_TTL_SECONDS;
+  const { data } = await models.UserSession.create({ userId, sessionId, expiresAt }).go();
+  return data;
+}
+
+// Resolve a cookie reference to its live session + user. DynamoDB TTL is eventual (an expired item can
+// linger), so we re-check expiresAt on read rather than trust the sweep.
+export async function loadSession(
+  models: Models,
+  ref: { userId: string; sessionId: string },
+): Promise<{ session: SessionItem; user: UserItem } | undefined> {
+  const { data: session } = await models.UserSession.get(ref).go();
+  if (!session || session.expiresAt <= nowSeconds()) return undefined;
+
+  const { data: user } = await models.User.get({ userId: ref.userId }).go();
+  if (!user) return undefined;
+
+  return { session, user };
+}
+
+export async function destroySession(models: Models, userId: string, sessionId: string): Promise<void> {
+  await models.UserSession.delete({ userId, sessionId }).go();
+}

--- a/components/backend-api/auth/system.ts
+++ b/components/backend-api/auth/system.ts
@@ -1,0 +1,30 @@
+import { randomBytes } from 'node:crypto';
+import type { EntityItem } from 'electrodb';
+import type { Models } from '../models';
+import type { SystemEntity } from '../models/system';
+
+type SystemItem = EntityItem<SystemEntity>;
+
+const newSecret = () => randomBytes(32).toString('base64url');
+const newSetupKey = () => randomBytes(24).toString('base64url');
+
+// Lazy first-run bootstrap (PLAN.md 10.1, #18). The System singleton isn't seeded at deploy time, so
+// the first request that needs it creates it: one session secret + a one-time setupKey. The setup URL
+// is logged (the operator reads it from CloudWatch) — the key is never exposed over the API. Setup
+// clears the key, permanently disabling the route.
+export async function ensureSystem(models: Models): Promise<SystemItem> {
+  const existing = await models.System.get({}).go();
+  if (existing.data) return existing.data;
+
+  const setupKey = newSetupKey();
+  try {
+    const { data } = await models.System.create({ sessionSecrets: [newSecret()], setupKey }).go();
+    console.log(`[thatblog] first-run setup required — POST /admin/setup/${setupKey}`);
+    return data;
+  } catch (err) {
+    // Lost a create race with a concurrent cold start; the winner's row is now present.
+    const raced = await models.System.get({}).go();
+    if (raced.data) return raced.data;
+    throw err;
+  }
+}

--- a/components/backend-api/context.ts
+++ b/components/backend-api/context.ts
@@ -1,0 +1,16 @@
+import type { EntityItem } from 'electrodb';
+import type { Models } from './models';
+import type { Loaders } from './loaders';
+import type { UserEntity } from './models/user';
+import type { UserSessionEntity } from './models/user-session';
+
+// Hono per-request variables. `models`/`loaders` are set for every request by the app middleware;
+// `user`/`session` are set only after requireAuth, so protected handlers can read them non-optionally.
+export type AppEnv = {
+  Variables: {
+    models: Models;
+    loaders: Loaders;
+    user: EntityItem<UserEntity>;
+    session: EntityItem<UserSessionEntity>;
+  };
+};

--- a/components/backend-api/loaders/index.spec.ts
+++ b/components/backend-api/loaders/index.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { testModels } from '../../../test/dynamo';
+import { newUserId } from '../models/ids';
+import { makeLoaders } from './index';
+
+const models = testModels();
+
+describe('loaders.userByEmail', () => {
+  it('hydrates users by email via gs1 and maps unknown emails to undefined', async () => {
+    const loaders = makeLoaders(models);
+    const [a, b] = [newUserId(), newUserId()];
+    const emailA = `${a}@example.com`;
+    const emailB = `${b}@example.com`;
+    await models.User.create({ userId: a, email: emailA, passwordHash: 'x', displayName: 'A' }).go();
+    await models.User.create({ userId: b, email: emailB, passwordHash: 'y', displayName: 'B' }).go();
+
+    // Three loads in one tick → one batch (N gs1 queries + a single BatchGet).
+    const [ua, ub, missing] = await Promise.all([
+      loaders.userByEmail.load(emailA),
+      loaders.userByEmail.load(emailB),
+      loaders.userByEmail.load('nobody@example.com'),
+    ]);
+
+    expect(ua?.userId).toBe(a);
+    expect(ub?.displayName).toBe('B');
+    expect(missing).toBeUndefined();
+  });
+
+  it('dedupes a repeated email within a request', async () => {
+    const loaders = makeLoaders(models);
+    const id = newUserId();
+    const email = `${id}@example.com`;
+    await models.User.create({ userId: id, email, passwordHash: 'x', displayName: 'Dup' }).go();
+
+    const [one, two] = await Promise.all([loaders.userByEmail.load(email), loaders.userByEmail.load(email)]);
+    expect(one).toBe(two); // same cached reference
+  });
+});

--- a/components/backend-api/loaders/index.ts
+++ b/components/backend-api/loaders/index.ts
@@ -1,0 +1,39 @@
+import type { EntityItem } from 'electrodb';
+import DataLoader from 'dataloader';
+import type { Models } from '../models';
+import type { UserEntity } from '../models/user';
+
+type UserItem = EntityItem<UserEntity>;
+
+// Per-request DataLoaders (built fresh per request in the app middleware), so they dedupe within a
+// request but never cache across users. Each loader follows the gs1 hydration pattern (PLAN.md 8.1,
+// [[electrodb-keys-only-gsi]]): query the KEYS_ONLY gs1 → collect ids from the keys → one BatchGet.
+export function makeLoaders(models: Models) {
+  // Login lookup: EMAILS#{email} → User. Callers must pass a lowercased email (keys are casing:'none',
+  // so the model does not normalise). Batches N emails into N index queries + a single BatchGet.
+  const userByEmail = new DataLoader<string, UserItem | undefined>(async (emails) => {
+    const userIds = await Promise.all(
+      emails.map(async (email) => {
+        const { data } = await models.User.query
+          .byEmail({ email })
+          // KEYS_ONLY: includeKeys surfaces the raw gs1sk (carries USERS#{userId}); ignoreOwnership
+          // skips the ownership stamp that KEYS_ONLY doesn't project. ElectroDB doesn't type these.
+          .go({ ignoreOwnership: true, data: 'includeKeys' });
+        const key = data[0] as unknown as { gs1sk?: string } | undefined;
+        return key?.gs1sk?.slice('USERS#'.length);
+      }),
+    );
+
+    const ids = [...new Set(userIds.filter((id): id is string => Boolean(id)))];
+    const { data: users } = ids.length
+      ? await models.User.get(ids.map((userId) => ({ userId }))).go()
+      : { data: [] as UserItem[] };
+    const byId = new Map(users.map((user) => [user.userId, user]));
+
+    return userIds.map((id) => (id ? byId.get(id) : undefined));
+  });
+
+  return { userByEmail };
+}
+
+export type Loaders = ReturnType<typeof makeLoaders>;

--- a/components/backend-api/package.json
+++ b/components/backend-api/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@thatblog/backend-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "lambda.ts",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.700.0",
+    "bcryptjs": "^3.0.0",
+    "dataloader": "^2.2.0",
     "electrodb": "^3.9.0",
     "hono": "^4.6.0",
-    "nanoid": "^5.0.0"
+    "nanoid": "^5.0.0",
+    "zod": "^4.0.0"
   }
 }

--- a/components/backend-api/routes/auth.ts
+++ b/components/backend-api/routes/auth.ts
@@ -1,0 +1,53 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { EntityItem } from 'electrodb';
+import type { AppEnv } from '../context';
+import type { UserEntity } from '../models/user';
+import { ensureSystem } from '../auth/system';
+import { verifyPassword } from '../auth/passwords';
+import { destroySession } from '../auth/sessions';
+import { issueSession, clearSessionCookie } from '../auth/http';
+import { requireAuth } from '../auth/middleware';
+
+const loginSchema = z.object({
+  email: z.email(),
+  password: z.string().min(1),
+});
+
+// The public view of a user — never leak passwordHash.
+const publicUser = (user: EntityItem<UserEntity>) => ({
+  userId: user.userId,
+  email: user.email,
+  displayName: user.displayName,
+});
+
+export const authRoutes = new Hono<AppEnv>();
+
+// Email/password login (PLAN.md 10.1). Look the user up by email via the gs1 DataLoader, verify the
+// bcrypt hash, then mint a session cookie. A missing user and a bad password return the same 401 so
+// the endpoint doesn't reveal which emails exist.
+authRoutes.post('/auth/login', async (c) => {
+  const body = await c.req.json().catch(() => undefined);
+  const parsed = loginSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+
+  const user = await c.var.loaders.userByEmail.load(parsed.data.email.toLowerCase());
+  if (!user || !(await verifyPassword(parsed.data.password, user.passwordHash))) {
+    return c.json({ error: 'invalid credentials' }, 401);
+  }
+
+  const system = await ensureSystem(c.var.models);
+  await issueSession(c, c.var.models, system.sessionSecrets, user.userId);
+
+  return c.json({ user: publicUser(user) });
+});
+
+// Current session's user — the round-trip that proves the cookie works.
+authRoutes.get('/auth/me', requireAuth, (c) => c.json({ user: publicUser(c.var.user) }));
+
+// Revoke the session (delete the record) and clear the cookie.
+authRoutes.post('/auth/logout', requireAuth, async (c) => {
+  await destroySession(c.var.models, c.var.user.userId, c.var.session.sessionId);
+  clearSessionCookie(c);
+  return c.json({ ok: true });
+});

--- a/components/backend-api/routes/setup.ts
+++ b/components/backend-api/routes/setup.ts
@@ -1,0 +1,63 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { AppEnv } from '../context';
+import { newBlogId, newUserId } from '../models/ids';
+import { ensureSystem } from '../auth/system';
+import { hashPassword } from '../auth/passwords';
+import { issueSession } from '../auth/http';
+
+// First-run setup (PLAN.md 10.1, #18): the setupKey in the path gates a one-shot that creates the
+// first owner User, the first Blog, its primary BlogDomain, and the owner MapBlogUser — then clears
+// the key, permanently disabling the route. The owner is auto-logged-in on success. (Default-theme
+// seeding is deferred until the theme system lands in a later milestone.)
+const setupSchema = z.object({
+  email: z.email(),
+  password: z.string().min(8),
+  displayName: z.string().min(1),
+  blog: z.object({
+    name: z.string().min(1),
+    host: z.string().min(1),
+  }),
+});
+
+export const setupRoutes = new Hono<AppEnv>();
+
+setupRoutes.post('/admin/setup/:key', async (c) => {
+  const models = c.var.models;
+  const system = await ensureSystem(models);
+
+  // Key already cleared → setup is done. A wrong key is a 404 so the route reveals nothing.
+  if (!system.setupKey) return c.json({ error: 'setup already completed' }, 410);
+  if (c.req.param('key') !== system.setupKey) return c.json({ error: 'not found' }, 404);
+
+  const body = await c.req.json().catch(() => undefined);
+  const parsed = setupSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
+
+  const userId = newUserId();
+  const blogId = newBlogId();
+  // Normalise in the caller — keys are casing:'none', so the models store email/host verbatim
+  // ([[electrodb-keys-only-gsi]]); lowercasing here keeps login + routing case-insensitive.
+  const email = parsed.data.email.toLowerCase();
+  const host = parsed.data.blog.host.toLowerCase();
+
+  await models.User.create({
+    userId,
+    email,
+    passwordHash: await hashPassword(parsed.data.password),
+    displayName: parsed.data.displayName,
+  }).go();
+  await models.Blog.create({ blogId, profile: { name: parsed.data.blog.name } }).go();
+  await models.BlogDomain.create({ blogId, host, type: 'primary', status: 'active' }).go();
+  await models.MapBlogUser.create({ blogId, userId, role: 'owner' }).go();
+
+  // Clear the key last, so a partial failure leaves setup retryable.
+  await models.System.patch({}).remove(['setupKey']).go();
+
+  await issueSession(c, models, system.sessionSecrets, userId);
+
+  return c.json(
+    { user: { userId, email, displayName: parsed.data.displayName }, blog: { blogId, name: parsed.data.blog.name } },
+    201,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thatblog",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "workspaces": ["components/*", "packages/*", "themes/*"],


### PR DESCRIPTION
Wires the identity/tenant models from v0.0.2 into the Hono `backend-api`, delivering the MVP milestone: **deploy → setup → log in via API**.

## What's in it

- **`createApp(models)` factory** (mirrors `makeModels`) — middleware attaches shared models + fresh per-request DataLoaders; the default export binds the env singletons for Lambda.
- **`loaders/userByEmail`** — gs1 `KEYS_ONLY` query → `BatchGet` hydration (the plan's login lookup pattern).
- **`auth/`**
  - `ensureSystem` — lazy first-run bootstrap; generates the session secret + one-time `setupKey`, logs the setup URL to CloudWatch (the key is never exposed over the API).
  - `bcryptjs` password hashing.
  - HMAC-SHA256 signed session cookie over the `System` `sessionSecrets` **list** — sign-with-newest / verify-against-all, so secret rotation forces no logouts.
  - 3-day TTL sessions (re-checked on read, since DynamoDB TTL is eventual); `requireAuth` middleware.
- **Routes**
  - `POST /admin/setup/:key` — creates the first `User` + `Blog` + primary `BlogDomain` + owner `MapBlogUser`, clears the key last (retryable on partial failure), auto-logs the owner in.
  - `POST /auth/login`, `GET /auth/me`, `POST /auth/logout`.
- **Deps:** `bcryptjs`, `zod` v4, `dataloader`.

## Deferred

- Default-theme seeding in setup — no theme system exists yet.
- The `userByEmail` loader's batch hydration is real but only ever sees one email per login today; the payoff arrives with multi-user page renders.

## Testing

`tsc --noEmit` clean; **21 unit tests pass** — cookie sign/verify/rotation/tamper, the gs1 loader (hydration + dedupe), and a full `setup → /auth/me → key-cleared (410) → bad login → case-insensitive login → logout-revokes` flow through `createApp`. Lambda bundle builds.