### PR TITLE
feat: v0.0.4 posts backend — Post entity, content blocks, authoring API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,9 +15,10 @@
     },
     "components/backend-api": {
       "name": "@thatblog/backend-api",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.700.0",
+        "@aws-sdk/lib-dynamodb": "^3.700.0",
         "bcryptjs": "^3.0.0",
         "dataloader": "^2.2.0",
         "electrodb": "^3.9.0",

--- a/components/backend-api/app.spec.ts
+++ b/components/backend-api/app.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { testModels } from '../../test/dynamo';
 import { createApp } from './app';
 import { ensureSystem } from './auth/system';
+import { listPosts } from './models/post';
 
 // One app bound to the Testcontainers table. This spec is the only one that touches the System
 // singleton / runs setup, so the shared table stays conflict-free across files.
@@ -92,6 +93,7 @@ describe('backend-api auth flow', () => {
 type PostBody = {
   post: {
     postId: string;
+    slug?: string;
     status: string;
     publishedAt?: string;
     blocks: { contentId: string; type: string; value: string }[];
@@ -173,5 +175,59 @@ describe('backend-api posts flow', () => {
     const { post } = (await res.json()) as PostBody;
     expect(post.status).toBe('published');
     expect(post.publishedAt).toBeTypeOf('string');
+
+    // On the public timeline (ls3) now.
+    const published = await listPosts(models.Post, 'byPublished', blogId);
+    expect(published.map((p) => p.postId)).toContain(postId);
+  });
+
+  it('unpublishes back to draft, clearing publishedAt and leaving the public timeline', async () => {
+    const res = await authedJson(`/admin/blogs/${blogId}/posts/${postId}/unpublish`, 'POST', {});
+    expect(res.status).toBe(200);
+    const { post } = (await res.json()) as PostBody;
+    expect(post.status).toBe('draft');
+    expect(post.publishedAt).toBeUndefined();
+
+    // ls3sk dropped → gone from the timeline index.
+    const published = await listPosts(models.Post, 'byPublished', blogId);
+    expect(published.map((p) => p.postId)).not.toContain(postId);
+  });
+
+  it('enforces per-blog slug uniqueness with a 409', async () => {
+    const first = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+      slug: 'hello-world',
+      blocks: [{ type: 'PLAIN_TEXT', value: 'has a slug' }],
+    });
+    expect(first.status).toBe(201);
+    expect(((await first.json()) as PostBody).post.slug).toBe('hello-world');
+
+    const clash = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+      slug: 'hello-world',
+      blocks: [{ type: 'PLAIN_TEXT', value: 'wants the same slug' }],
+    });
+    expect(clash.status).toBe(409);
+  });
+
+  it('deletes a post with its blocks and frees the slug', async () => {
+    const created = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+      slug: 'delete-me',
+      blocks: [{ type: 'PLAIN_TEXT', value: 'temporary' }],
+    });
+    const { post } = (await created.json()) as PostBody;
+
+    const del = await authedJson(`/admin/blogs/${blogId}/posts/${post.postId}`, 'DELETE', {});
+    expect(del.status).toBe(204);
+
+    // Gone: the post 404s and its blocks are swept.
+    const get = await app.request(`/admin/blogs/${blogId}/posts/${post.postId}`, { headers: { cookie: setupCookie } });
+    expect(get.status).toBe(404);
+    expect(await models.content.listBlocks(blogId, post.postId)).toHaveLength(0);
+
+    // The slug claim was released, so it can be reused.
+    const reuse = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+      slug: 'delete-me',
+      blocks: [{ type: 'PLAIN_TEXT', value: 'reused slug' }],
+    });
+    expect(reuse.status).toBe(201);
   });
 });

--- a/components/backend-api/app.spec.ts
+++ b/components/backend-api/app.spec.ts
@@ -19,6 +19,11 @@ const cookieFrom = (res: Response): string => (res.headers.get('set-cookie') ?? 
 
 const login = (email: string, password: string) => app.request('/auth/login', json({ email, password }));
 
+// Captured by setup and reused by the posts flow below (setup is one-shot, so these describes share
+// the one owner + blog the run creates).
+let setupCookie = '';
+let blogId = '';
+
 describe('backend-api auth flow', () => {
   const creds = {
     email: 'Owner@Example.com',
@@ -26,7 +31,6 @@ describe('backend-api auth flow', () => {
     displayName: 'The Owner',
     blog: { name: 'My Blog', host: 'Blog.Example.com' },
   };
-  let setupCookie = '';
 
   it('completes first-run setup, normalising email/host and auto-logging in', async () => {
     const system = await ensureSystem(models);
@@ -40,6 +44,7 @@ describe('backend-api auth flow', () => {
     expect(body.blog.blogId).toMatch(/^b/);
 
     setupCookie = cookieFrom(res);
+    blogId = body.blog.blogId;
     expect(setupCookie).toContain('thatblog_session=');
   });
 
@@ -81,5 +86,92 @@ describe('backend-api auth flow', () => {
 
     const me = await app.request('/auth/me', { headers: { cookie } });
     expect(me.status).toBe(401); // session record deleted
+  });
+});
+
+type PostBody = {
+  post: {
+    postId: string;
+    status: string;
+    publishedAt?: string;
+    blocks: { contentId: string; type: string; value: string }[];
+  };
+};
+
+describe('backend-api posts flow', () => {
+  // Reuses the owner cookie + blog from the setup above.
+  const authedJson = (path: string, method: string, body: unknown) =>
+    app.request(path, {
+      method,
+      headers: { 'content-type': 'application/json', cookie: setupCookie },
+      body: JSON.stringify(body),
+    });
+
+  let postId = '';
+
+  it('rejects authoring without a session', async () => {
+    const res = await app.request(
+      `/admin/blogs/${blogId}/posts`,
+      json({ blocks: [{ type: 'PLAIN_TEXT', value: 'hi' }] }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects authoring on a blog the user is not a member of', async () => {
+    const res = await authedJson('/admin/blogs/bNOTMINE/posts', 'POST', {
+      blocks: [{ type: 'PLAIN_TEXT', value: 'hi' }],
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('creates a draft short post with its block', async () => {
+    const res = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+      blocks: [{ type: 'PLAIN_TEXT', value: 'my first post' }],
+    });
+    expect(res.status).toBe(201);
+
+    const { post } = (await res.json()) as PostBody;
+    postId = post.postId;
+    expect(post.postId).toMatch(/^p/);
+    expect(post.status).toBe('draft');
+    expect(post.publishedAt).toBeUndefined();
+    expect(post.blocks).toEqual([{ contentId: expect.any(String), type: 'PLAIN_TEXT', value: 'my first post' }]);
+  });
+
+  it('reads the post back with its body in order', async () => {
+    const res = await app.request(`/admin/blogs/${blogId}/posts/${postId}`, { headers: { cookie: setupCookie } });
+    expect(res.status).toBe(200);
+    const { post } = (await res.json()) as PostBody;
+    expect(post.blocks[0]?.value).toBe('my first post');
+  });
+
+  it("lists the blog's posts", async () => {
+    const res = await app.request(`/admin/blogs/${blogId}/posts`, { headers: { cookie: setupCookie } });
+    expect(res.status).toBe(200);
+    const { posts } = (await res.json()) as { posts: { postId: string }[] };
+    expect(posts.map((p) => p.postId)).toContain(postId);
+  });
+
+  it('replaces the whole body on edit, leaving no stale blocks', async () => {
+    const res = await authedJson(`/admin/blogs/${blogId}/posts/${postId}`, 'PATCH', {
+      blocks: [{ type: 'PLAIN_TEXT', value: 'edited' }],
+    });
+    expect(res.status).toBe(200);
+    const { post } = (await res.json()) as PostBody;
+    expect(post.blocks).toEqual([{ contentId: expect.any(String), type: 'PLAIN_TEXT', value: 'edited' }]);
+
+    // The replace deletes the old block in the same transaction, so the partition holds exactly the
+    // new block — no orphans drifting from content.values (#20).
+    const stored = await models.content.listBlocks(blogId, postId);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.value).toBe('edited');
+  });
+
+  it('publishes the post, stamping publishedAt', async () => {
+    const res = await authedJson(`/admin/blogs/${blogId}/posts/${postId}/publish`, 'POST', {});
+    expect(res.status).toBe(200);
+    const { post } = (await res.json()) as PostBody;
+    expect(post.status).toBe('published');
+    expect(post.publishedAt).toBeTypeOf('string');
   });
 });

--- a/components/backend-api/app.ts
+++ b/components/backend-api/app.ts
@@ -4,6 +4,7 @@ import { makeLoaders } from './loaders';
 import type { AppEnv } from './context';
 import { setupRoutes } from './routes/setup';
 import { authRoutes } from './routes/auth';
+import { postsRoutes } from './routes/posts';
 
 // createApp takes the model set so tests can point the whole app at a Testcontainers table (mirrors
 // makeModels); the default export binds the env-driven singletons for the Lambda.
@@ -21,12 +22,13 @@ export function createApp(models: Models) {
     c.json({
       status: 'ok',
       service: 'backend-api',
-      version: '0.0.3',
+      version: '0.0.4',
     }),
   );
 
   app.route('/', setupRoutes);
   app.route('/', authRoutes);
+  app.route('/', postsRoutes);
 
   return app;
 }

--- a/components/backend-api/auth/blog.ts
+++ b/components/backend-api/auth/blog.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from 'hono';
+import type { AppEnv } from '../context';
+
+// Per-blog authorization, layered on top of requireAuth (PLAN.md 10.1): the authenticated user must
+// hold a MapBlogUser membership for the :blogId in the path. The membership carries the role, which
+// is attached to the request so handlers can gate on it — v0.0.4 lets any role (owner/admin/editor)
+// author, so presence of a membership is enough. No membership → 403.
+export const requireBlogMember: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const blogId = c.req.param('blogId');
+  if (!blogId) return c.json({ error: 'not found' }, 404);
+
+  const { data } = await c.var.models.MapBlogUser.get({ blogId, userId: c.var.user.userId }).go();
+  if (!data) return c.json({ error: 'forbidden' }, 403);
+
+  c.set('membership', data);
+  await next();
+};

--- a/components/backend-api/content/blocks.spec.ts
+++ b/components/backend-api/content/blocks.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { blockSchema, newContentId } from './blocks';
+
+describe('block schema', () => {
+  it('accepts a PLAIN_TEXT block', () => {
+    const parsed = blockSchema.safeParse({ type: 'PLAIN_TEXT', value: 'Hello world' });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an unknown block type', () => {
+    expect(blockSchema.safeParse({ type: 'MYSTERY', value: 'x' }).success).toBe(false);
+  });
+
+  it('rejects an empty value', () => {
+    expect(blockSchema.safeParse({ type: 'PLAIN_TEXT', value: '' }).success).toBe(false);
+  });
+
+  it('strips fields that are not part of the block (e.g. storage keys)', () => {
+    const parsed = blockSchema.parse({ type: 'PLAIN_TEXT', value: 'hi', pk: 'x', sk: 'y', contentId: 'z' });
+    expect(parsed).toEqual({ type: 'PLAIN_TEXT', value: 'hi' });
+  });
+
+  it('mints opaque, unique content ids', () => {
+    expect(newContentId()).not.toBe(newContentId());
+  });
+});

--- a/components/backend-api/content/blocks.ts
+++ b/components/backend-api/content/blocks.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { nanoid } from 'nanoid';
+
+// Content blocks are hand-rolled, not ElectroDB (PLAN.md 8.2): each block is its own item under the
+// post's content partition, and its shape is validated here with a Zod discriminated union on `type`
+// rather than a fixed table schema — so new block types (MEDIA, LINK, …) slot into the array below
+// without any migration, and the Liquid renderer (0.0.5+) switches on the same `type`. v0.0.4 ships
+// the single block a short post needs.
+const plainText = z.object({
+  type: z.literal('PLAIN_TEXT'),
+  value: z.string().min(1),
+});
+
+export const blockSchema = z.discriminatedUnion('type', [plainText]);
+
+export type Block = z.infer<typeof blockSchema>;
+
+// A block as it comes back from the store: the validated block plus its opaque id (the item's sk,
+// also referenced from Post.content.values). Timestamps live on the block item but aren't exposed.
+export type StoredBlock = Block & { contentId: string };
+
+export const newContentId = () => nanoid();

--- a/components/backend-api/content/store.spec.ts
+++ b/components/backend-api/content/store.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { testModels } from '../../../test/dynamo';
+import { newBlogId, newPostId } from '../models/ids';
+import { newContentId } from './blocks';
+
+const { content } = testModels();
+
+describe('content store', () => {
+  it('round-trips blocks written in one transaction, reading them all in one query', async () => {
+    const blogId = newBlogId();
+    const postId = newPostId();
+    const a = newContentId();
+    const b = newContentId();
+
+    await content.write([
+      content.putBlock(blogId, postId, a, { type: 'PLAIN_TEXT', value: 'first' }),
+      content.putBlock(blogId, postId, b, { type: 'PLAIN_TEXT', value: 'second' }),
+    ]);
+
+    const stored = await content.listBlocks(blogId, postId);
+    expect(stored.map((s) => s.contentId).sort()).toEqual([a, b].sort());
+    expect(new Map(stored.map((s) => [s.contentId, s.value])).get(a)).toBe('first');
+    // Blocks are scoped to their post partition — a different post sees nothing.
+    expect(await content.listBlocks(blogId, newPostId())).toHaveLength(0);
+  });
+
+  it('deletes blocks transactionally', async () => {
+    const blogId = newBlogId();
+    const postId = newPostId();
+    const id = newContentId();
+
+    await content.write([content.putBlock(blogId, postId, id, { type: 'PLAIN_TEXT', value: 'gone soon' })]);
+    expect(await content.listBlocks(blogId, postId)).toHaveLength(1);
+
+    await content.write([content.deleteBlock(blogId, postId, id)]);
+    expect(await content.listBlocks(blogId, postId)).toHaveLength(0);
+  });
+});

--- a/components/backend-api/content/store.ts
+++ b/components/backend-api/content/store.ts
@@ -65,3 +65,8 @@ export function makeContentStore(client: DynamoDBClient, table: string) {
 
 export type ContentStore = ReturnType<typeof makeContentStore>;
 export type { TransactItem };
+
+// A TransactWrite is cancelled atomically when any item's condition fails (e.g. a slug-claim's
+// attribute_not_exists), surfacing as TransactionCanceledException. Callers translate that to a 409.
+export const isWriteConflict = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && (err as { name?: string }).name === 'TransactionCanceledException';

--- a/components/backend-api/content/store.ts
+++ b/components/backend-api/content/store.ts
@@ -1,0 +1,67 @@
+import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  TransactWriteCommand,
+  type TransactWriteCommandInput,
+} from '@aws-sdk/lib-dynamodb';
+import { blockSchema, type Block, type StoredBlock } from './blocks';
+
+type TransactItem = NonNullable<TransactWriteCommandInput['TransactItems']>[number];
+
+// Strip the storage/key fields and re-validate the block body, so a corrupt or unknown-type item
+// fails loudly rather than rendering as garbage.
+const toStoredBlock = (item: Record<string, unknown>): StoredBlock => ({
+  contentId: String(item.contentId),
+  ...blockSchema.parse(item),
+});
+
+// The hand-rolled sibling to the ElectroDB entities (PLAN.md 8.2): raw pk/sk access to a post's
+// content blocks. All blocks for a post share one partition, so a whole body hydrates in a single
+// query. Block writes always travel with the parent Post's content.values[] in one TransactWrite
+// (#20) — this store builds the block transact-items (pure) and runs the transaction; the caller
+// pairs them with the Post's ElectroDB `.params()`, so the ordered list and its blocks never drift.
+export function makeContentStore(client: DynamoDBClient, table: string) {
+  const doc = DynamoDBDocumentClient.from(client);
+  const partition = (blogId: string, postId: string) => `BLOGS#${blogId}#POSTS#${postId}#CONTENTS`;
+
+  return {
+    // Every block for a post. sk order is opaque (contentIds are random) — callers order the result
+    // by the parent's content.values[].
+    async listBlocks(blogId: string, postId: string): Promise<StoredBlock[]> {
+      const out = await doc.send(
+        new QueryCommand({
+          TableName: table,
+          KeyConditionExpression: '#pk = :pk',
+          ExpressionAttributeNames: { '#pk': 'pk' },
+          ExpressionAttributeValues: { ':pk': partition(blogId, postId) },
+        }),
+      );
+      return (out.Items ?? []).map(toStoredBlock);
+    },
+
+    putBlock(blogId: string, postId: string, contentId: string, block: Block): TransactItem {
+      const now = new Date().toISOString();
+      return {
+        Put: {
+          TableName: table,
+          Item: { pk: partition(blogId, postId), sk: contentId, contentId, ...block, createdAt: now, updatedAt: now },
+        },
+      };
+    },
+
+    deleteBlock(blogId: string, postId: string, contentId: string): TransactItem {
+      return { Delete: { TableName: table, Key: { pk: partition(blogId, postId), sk: contentId } } };
+    },
+
+    // Atomic write of the Post item + its blocks. ElectroDB `.params()` returns DocumentClient-shaped
+    // params, so the caller's `{ Put }`/`{ Update }` for the Post drops straight in beside the block
+    // items. DynamoDB caps a transaction at 100 items — routes bound the block count to stay under it.
+    async write(items: TransactItem[]): Promise<void> {
+      await doc.send(new TransactWriteCommand({ TransactItems: items }));
+    },
+  };
+}
+
+export type ContentStore = ReturnType<typeof makeContentStore>;
+export type { TransactItem };

--- a/components/backend-api/context.ts
+++ b/components/backend-api/context.ts
@@ -3,14 +3,17 @@ import type { Models } from './models';
 import type { Loaders } from './loaders';
 import type { UserEntity } from './models/user';
 import type { UserSessionEntity } from './models/user-session';
+import type { MapBlogUserEntity } from './models/map-blog-user';
 
 // Hono per-request variables. `models`/`loaders` are set for every request by the app middleware;
-// `user`/`session` are set only after requireAuth, so protected handlers can read them non-optionally.
+// `user`/`session` are set only after requireAuth, and `membership` only after requireBlogMember, so
+// the handlers behind each gate can read them non-optionally.
 export type AppEnv = {
   Variables: {
     models: Models;
     loaders: Loaders;
     user: EntityItem<UserEntity>;
     session: EntityItem<UserSessionEntity>;
+    membership: EntityItem<MapBlogUserEntity>;
   };
 };

--- a/components/backend-api/models/ids.ts
+++ b/components/backend-api/models/ids.ts
@@ -5,3 +5,6 @@ import { nanoid } from 'nanoid';
 export const newBlogId = () => `b${nanoid()}`;
 export const newUserId = () => nanoid();
 export const newSessionId = () => nanoid(32);
+// postId is p-prefixed so it reads clearly in keys/logs (like blogId). Content block ids are opaque
+// (PLAN.md 8.2) — they only ever appear as a block's sk and inside Post.content.values.
+export const newPostId = () => `p${nanoid()}`;

--- a/components/backend-api/models/index.ts
+++ b/components/backend-api/models/index.ts
@@ -6,6 +6,7 @@ import { makeUser } from './user';
 import { makeMapBlogUser } from './map-blog-user';
 import { makeUserSession } from './user-session';
 import { makePost } from './post';
+import { makePostSlug } from './post-slug';
 import { makeContentStore } from '../content/store';
 
 // The env-driven singletons (System, Blog, …) are the default import for Lambda code. makeModels
@@ -21,6 +22,7 @@ export const makeModels = (client: DynamoDBClient, table: string) => ({
   MapBlogUser: makeMapBlogUser(client, table),
   UserSession: makeUserSession(client, table),
   Post: makePost(client, table),
+  PostSlug: makePostSlug(client, table),
   content: makeContentStore(client, table),
 });
 
@@ -35,3 +37,4 @@ export * from './user';
 export * from './map-blog-user';
 export * from './user-session';
 export * from './post';
+export * from './post-slug';

--- a/components/backend-api/models/index.ts
+++ b/components/backend-api/models/index.ts
@@ -5,10 +5,14 @@ import { makeBlogDomain } from './blog-domain';
 import { makeUser } from './user';
 import { makeMapBlogUser } from './map-blog-user';
 import { makeUserSession } from './user-session';
+import { makePost } from './post';
+import { makeContentStore } from '../content/store';
 
 // The env-driven singletons (System, Blog, …) are the default import for Lambda code. makeModels
 // rebuilds the same entities against an arbitrary client/table — used by unit tests to point every
-// model at a Testcontainers DynamoDB without touching import-time env.
+// model at a Testcontainers DynamoDB without touching import-time env. `content` is the hand-rolled
+// block store (PLAN.md 8.2) — not an ElectroDB entity, but built from the same client/table so it
+// travels with the models it sits beside in the partition.
 export const makeModels = (client: DynamoDBClient, table: string) => ({
   System: makeSystem(client, table),
   Blog: makeBlog(client, table),
@@ -16,6 +20,8 @@ export const makeModels = (client: DynamoDBClient, table: string) => ({
   User: makeUser(client, table),
   MapBlogUser: makeMapBlogUser(client, table),
   UserSession: makeUserSession(client, table),
+  Post: makePost(client, table),
+  content: makeContentStore(client, table),
 });
 
 export type Models = ReturnType<typeof makeModels>;
@@ -28,3 +34,4 @@ export * from './blog-domain';
 export * from './user';
 export * from './map-blog-user';
 export * from './user-session';
+export * from './post';

--- a/components/backend-api/models/post-slug.spec.ts
+++ b/components/backend-api/models/post-slug.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { testModels } from '../../../test/dynamo';
+import { newBlogId, newPostId } from './ids';
+
+const { PostSlug } = testModels();
+
+describe('PostSlug', () => {
+  it('claims a slug and rejects a duplicate within the same blog', async () => {
+    const blogId = newBlogId();
+    await PostSlug.create({ blogId, slug: 'hello-world', postId: newPostId() }).go();
+
+    await expect(PostSlug.create({ blogId, slug: 'hello-world', postId: newPostId() }).go()).rejects.toThrow();
+  });
+
+  it('scopes uniqueness per blog — the same slug is free in another blog', async () => {
+    const slug = 'shared-slug';
+    await PostSlug.create({ blogId: newBlogId(), slug, postId: newPostId() }).go();
+    await expect(PostSlug.create({ blogId: newBlogId(), slug, postId: newPostId() }).go()).resolves.toBeDefined();
+  });
+
+  it('frees the slug once released', async () => {
+    const blogId = newBlogId();
+    await PostSlug.create({ blogId, slug: 'reusable', postId: newPostId() }).go();
+    await PostSlug.delete({ blogId, slug: 'reusable' }).go();
+    await expect(PostSlug.create({ blogId, slug: 'reusable', postId: newPostId() }).go()).resolves.toBeDefined();
+  });
+});

--- a/components/backend-api/models/post-slug.ts
+++ b/components/backend-api/models/post-slug.ts
@@ -1,0 +1,29 @@
+import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { Entity } from 'electrodb';
+import { client, TABLE_NAME } from './client';
+
+// A per-blog uniqueness guard for post slugs: one item per claimed slug, pk=BLOGS#{blogId} /
+// sk=SLUGS#{slug} (its own prefix in the shared blog partition). Written transactionally alongside
+// the Post — ElectroDB's `.create()` carries `attribute_not_exists`, so a duplicate slug cancels the
+// whole transaction (surfaced as a 409). Slugs are stored verbatim (casing:'none'); normalisation +
+// generation are the caller's job (deferred). `postId` also makes this the slug→post resolver the
+// public site (0.0.5) needs. Released on slug change / post delete.
+export const postSlugSchema = {
+  model: { service: 'thatblog', entity: 'postSlug', version: '1' },
+  attributes: {
+    blogId: { type: 'string', required: true, readOnly: true },
+    slug: { type: 'string', required: true, readOnly: true },
+    postId: { type: 'string', required: true },
+  },
+  indexes: {
+    primary: {
+      pk: { field: 'pk', composite: ['blogId'], template: 'BLOGS#${blogId}', casing: 'none' },
+      sk: { field: 'sk', composite: ['slug'], template: 'SLUGS#${slug}', casing: 'none' },
+    },
+  },
+} as const;
+
+export const makePostSlug = (c: DynamoDBClient, table: string) => new Entity(postSlugSchema, { client: c, table });
+
+export const PostSlug = makePostSlug(client, TABLE_NAME);
+export type PostSlugEntity = ReturnType<typeof makePostSlug>;

--- a/components/backend-api/models/post.spec.ts
+++ b/components/backend-api/models/post.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { testModels } from '../../../test/dynamo';
+import { newBlogId, newPostId } from './ids';
+import { listPosts } from './post';
+
+const { Post } = testModels();
+
+const draft = (blogId: string, postId: string) => ({
+  blogId,
+  postId,
+  content: { values: ['c1'] },
+});
+
+describe('Post', () => {
+  it('defaults a new post to a draft short and does not leak key fields', async () => {
+    const blogId = newBlogId();
+    const postId = newPostId();
+    await Post.create(draft(blogId, postId)).go();
+
+    const { data } = await Post.get({ blogId, postId }).go();
+    expect(data?.type).toBe('short');
+    expect(data?.status).toBe('draft');
+    expect(data?.pinned).toBe(false);
+    expect(data?.publishedAt).toBeUndefined();
+    expect(data?.content.values).toEqual(['c1']);
+    expect(data).not.toHaveProperty('pk');
+    expect(data).not.toHaveProperty('ls3sk');
+  });
+
+  it("lists a blog's posts newest-first via ls1, hydrating the KEYS_ONLY index", async () => {
+    const blogId = newBlogId();
+    const older = newPostId();
+    const newer = newPostId();
+    await Post.create(draft(blogId, older)).go();
+    await new Promise((r) => setTimeout(r, 5)); // distinct createdAt so the order is deterministic
+    await Post.create(draft(blogId, newer)).go();
+
+    const data = await listPosts(Post, 'byCreated', blogId, { order: 'desc' });
+    expect(data.map((p) => p.postId)).toEqual([newer, older]);
+    // listPosts BatchGets the base table, so the KEYS_ONLY index still yields full posts.
+    expect(data[0]?.content.values).toEqual(['c1']);
+  });
+
+  it('is absent from the published index until published (sparse ls3), then present', async () => {
+    const blogId = newBlogId();
+    const postId = newPostId();
+    await Post.create(draft(blogId, postId)).go();
+
+    expect(await listPosts(Post, 'byPublished', blogId)).toHaveLength(0); // draft has no ls3sk
+
+    const publishedAt = new Date().toISOString();
+    await Post.patch({ blogId, postId }).set({ status: 'published', publishedAt }).go();
+
+    const after = await listPosts(Post, 'byPublished', blogId);
+    expect(after.map((p) => p.postId)).toEqual([postId]);
+    expect(after[0]?.publishedAt).toBe(publishedAt);
+  });
+});

--- a/components/backend-api/models/post.ts
+++ b/components/backend-api/models/post.ts
@@ -1,0 +1,98 @@
+import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { Entity, type EntityItem } from 'electrodb';
+import { client, TABLE_NAME } from './client';
+import { timestamps } from './_shared';
+
+// A post shares the blog partition (PLAN.md 8, #12): pk=BLOGS#{blogId} / sk=POSTS#{postId}, so it
+// sits alongside the Blog ITEM, its BlogDomain/MapBlogUser items, and the hand-rolled content blocks
+// (BLOGS#{blogId}#POSTS#…#CONTENTS — a distinct prefix). `content` carries the ordered list of block
+// ids (the blocks themselves are hand-rolled, PLAN.md 8.2). LSIs sort a blog's posts three ways:
+//   ls1 = createdAt (admin, newest first), ls2 = updatedAt (admin, recently edited),
+//   ls3 = publishedAt (public timeline). publishedAt is only set once published, so ls3sk is written
+// only for published posts — the index is sparse and drafts never appear on the public timeline, and
+// a future publishedAt falls outside a `<= now` query (scheduled posts hide themselves, #21).
+export const postSchema = {
+  model: { service: 'thatblog', entity: 'post', version: '1' },
+  attributes: {
+    blogId: { type: 'string', required: true, readOnly: true },
+    postId: { type: 'string', required: true, readOnly: true },
+    type: { type: ['short', 'article'] as const, required: true, default: 'short' },
+    slug: { type: 'string' },
+    status: { type: ['draft', 'published'] as const, required: true, default: 'draft' },
+    publishedAt: { type: 'string' },
+    pinned: { type: 'boolean', required: true, default: false },
+    content: {
+      type: 'map',
+      required: true,
+      properties: {
+        // Ordered contentIds — order is the array order, so reordering is one write to this parent
+        // (no per-block position keys). excerpt marks the contentId where the timeline preview ends.
+        values: { type: 'list', required: true, items: { type: 'string' } },
+        excerpt: { type: 'string' },
+      },
+    },
+    ...timestamps,
+  },
+  indexes: {
+    primary: {
+      pk: { field: 'pk', composite: ['blogId'], template: 'BLOGS#${blogId}', casing: 'none' },
+      sk: { field: 'sk', composite: ['postId'], template: 'POSTS#${postId}', casing: 'none' },
+    },
+    // LSIs share the blog pk; the sort key is a raw ISO timestamp (casing:'none' keeps it verbatim so
+    // it sorts and compares against `new Date().toISOString()`). publishedAt is optional → ls3 sparse.
+    byCreated: {
+      index: 'ls1',
+      pk: { field: 'pk', composite: ['blogId'], template: 'BLOGS#${blogId}', casing: 'none' },
+      sk: { field: 'ls1sk', composite: ['createdAt'], template: '${createdAt}', casing: 'none' },
+    },
+    byUpdated: {
+      index: 'ls2',
+      pk: { field: 'pk', composite: ['blogId'], template: 'BLOGS#${blogId}', casing: 'none' },
+      sk: { field: 'ls2sk', composite: ['updatedAt'], template: '${updatedAt}', casing: 'none' },
+    },
+    byPublished: {
+      index: 'ls3',
+      pk: { field: 'pk', composite: ['blogId'], template: 'BLOGS#${blogId}', casing: 'none' },
+      sk: { field: 'ls3sk', composite: ['publishedAt'], template: '${publishedAt}', casing: 'none' },
+    },
+  },
+} as const;
+
+export const makePost = (c: DynamoDBClient, table: string) => new Entity(postSchema, { client: c, table });
+
+export const Post = makePost(client, TABLE_NAME);
+export type PostEntity = ReturnType<typeof makePost>;
+export type PostItem = EntityItem<PostEntity>;
+
+// List a blog's posts via one of the timestamp LSIs. The table projects every index KEYS_ONLY
+// ([[electrodb-keys-only-gsi]]), and — contrary to the "LSIs auto-fetch" note in PLAN.md 8.1 —
+// DynamoDB returns keys only here too, so this follows the same shape as the gs1 loaders: query the
+// index for ordered keys, read each postId out of the sk, then BatchGet the full posts. BatchGet is
+// unordered, so we restore the index order from the id list. byPublished is sparse (drafts have no
+// publishedAt → no ls3sk), so it naturally returns only published posts.
+const POSTS_PREFIX = 'POSTS#';
+export async function listPosts(
+  entity: PostEntity,
+  index: 'byCreated' | 'byUpdated' | 'byPublished',
+  blogId: string,
+  opts: { order?: 'asc' | 'desc' } = {},
+): Promise<PostItem[]> {
+  // The three timestamp LSIs share the { blogId } composite; index into them dynamically. ElectroDB
+  // types each query method distinctly (and doesn't type includeKeys' raw sk), so narrow to the shape
+  // this helper uses.
+  type KeyQuery = (composite: { blogId: string }) => {
+    go: (opts: {
+      ignoreOwnership: true;
+      data: 'includeKeys';
+      order?: 'asc' | 'desc';
+    }) => Promise<{ data: { sk: string }[] }>;
+  };
+  const run = entity.query[index] as unknown as KeyQuery;
+  const { data: keys } = await run({ blogId }).go({ ignoreOwnership: true, data: 'includeKeys', order: opts.order });
+  const ids = keys.map((k) => k.sk.slice(POSTS_PREFIX.length));
+  if (!ids.length) return [];
+
+  const { data: posts } = await entity.get(ids.map((postId) => ({ blogId, postId }))).go();
+  const byId = new Map(posts.map((post) => [post.postId, post]));
+  return ids.map((id) => byId.get(id)).filter((post): post is PostItem => Boolean(post));
+}

--- a/components/backend-api/models/post.ts
+++ b/components/backend-api/models/post.ts
@@ -65,12 +65,9 @@ export type PostEntity = ReturnType<typeof makePost>;
 export type PostItem = EntityItem<PostEntity>;
 
 // List a blog's posts via one of the timestamp LSIs. The table projects every index KEYS_ONLY
-// ([[electrodb-keys-only-gsi]]), and — contrary to the "LSIs auto-fetch" note in PLAN.md 8.1 —
-// DynamoDB returns keys only here too, so this follows the same shape as the gs1 loaders: query the
-// index for ordered keys, read each postId out of the sk, then BatchGet the full posts. BatchGet is
-// unordered, so we restore the index order from the id list. byPublished is sparse (drafts have no
-// publishedAt → no ls3sk), so it naturally returns only published posts.
-const POSTS_PREFIX = 'POSTS#';
+// ([[electrodb-keys-only-gsi]]), so a plain read returns keys only — but ElectroDB's `hydrate: true`
+// does the follow-on fetch to the base table for us, returning full items in index order. byPublished
+// is sparse (drafts have no publishedAt → no ls3sk), so it naturally returns only published posts.
 export async function listPosts(
   entity: PostEntity,
   index: 'byCreated' | 'byUpdated' | 'byPublished',
@@ -78,21 +75,11 @@ export async function listPosts(
   opts: { order?: 'asc' | 'desc' } = {},
 ): Promise<PostItem[]> {
   // The three timestamp LSIs share the { blogId } composite; index into them dynamically. ElectroDB
-  // types each query method distinctly (and doesn't type includeKeys' raw sk), so narrow to the shape
-  // this helper uses.
-  type KeyQuery = (composite: { blogId: string }) => {
-    go: (opts: {
-      ignoreOwnership: true;
-      data: 'includeKeys';
-      order?: 'asc' | 'desc';
-    }) => Promise<{ data: { sk: string }[] }>;
+  // types each query method distinctly, so narrow to the shape this helper uses.
+  type IndexQuery = (composite: { blogId: string }) => {
+    go: (opts: { hydrate: true; order?: 'asc' | 'desc' }) => Promise<{ data: PostItem[] }>;
   };
-  const run = entity.query[index] as unknown as KeyQuery;
-  const { data: keys } = await run({ blogId }).go({ ignoreOwnership: true, data: 'includeKeys', order: opts.order });
-  const ids = keys.map((k) => k.sk.slice(POSTS_PREFIX.length));
-  if (!ids.length) return [];
-
-  const { data: posts } = await entity.get(ids.map((postId) => ({ blogId, postId }))).go();
-  const byId = new Map(posts.map((post) => [post.postId, post]));
-  return ids.map((id) => byId.get(id)).filter((post): post is PostItem => Boolean(post));
+  const run = entity.query[index] as unknown as IndexQuery;
+  const { data } = await run({ blogId }).go({ hydrate: true, order: opts.order });
+  return data;
 }

--- a/components/backend-api/package.json
+++ b/components/backend-api/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@thatblog/backend-api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "main": "lambda.ts",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.700.0",
+    "@aws-sdk/lib-dynamodb": "^3.700.0",
     "bcryptjs": "^3.0.0",
     "dataloader": "^2.2.0",
     "electrodb": "^3.9.0",

--- a/components/backend-api/routes/posts.ts
+++ b/components/backend-api/routes/posts.ts
@@ -1,0 +1,161 @@
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { z } from 'zod';
+import type { EntityItem } from 'electrodb';
+import type { AppEnv } from '../context';
+import { listPosts, type PostEntity } from '../models/post';
+import { newPostId } from '../models/ids';
+import { blockSchema, newContentId, type StoredBlock } from '../content/blocks';
+import type { TransactItem } from '../content/store';
+import { requireAuth } from '../auth/middleware';
+import { requireBlogMember } from '../auth/blog';
+
+// Blocks per post are bounded so a whole-body replace (delete old + put new + the Post item) stays
+// under DynamoDB's 100-item TransactWrite cap: 25 old + 25 new + 1 post = 51. Short posts use one.
+const MAX_BLOCKS = 25;
+
+const createSchema = z.object({
+  type: z.enum(['short', 'article']).default('short'),
+  slug: z.string().min(1).optional(),
+  blocks: z.array(blockSchema).min(1).max(MAX_BLOCKS),
+});
+
+const updateSchema = z.object({
+  slug: z.string().min(1).optional(),
+  blocks: z.array(blockSchema).min(1).max(MAX_BLOCKS).optional(),
+});
+
+const publishSchema = z.object({ publishedAt: z.iso.datetime().optional() }).optional();
+
+// The API view of a post: its metadata plus its blocks in content.values order (drop the raw
+// content.values / key plumbing). A body is one query; blocks are ordered here, not in DynamoDB.
+const postView = (post: EntityItem<PostEntity>, stored: StoredBlock[]) => {
+  const byId = new Map(stored.map((b) => [b.contentId, b]));
+  const blocks = post.content.values.map((id) => byId.get(id)).filter((b): b is StoredBlock => Boolean(b));
+  return {
+    blogId: post.blogId,
+    postId: post.postId,
+    type: post.type,
+    slug: post.slug,
+    status: post.status,
+    publishedAt: post.publishedAt,
+    pinned: post.pinned,
+    createdAt: post.createdAt,
+    updatedAt: post.updatedAt,
+    blocks,
+  };
+};
+
+// Read a post + hydrate its body. Returns undefined when the post is gone.
+const readPost = async (c: Context<AppEnv>, blogId: string, postId: string) => {
+  const { data: post } = await c.var.models.Post.get({ blogId, postId }).go();
+  if (!post) return undefined;
+  const stored = await c.var.models.content.listBlocks(blogId, postId);
+  return postView(post, stored);
+};
+
+const parseBody = async (c: Context<AppEnv>) => c.req.json().catch(() => undefined);
+
+const posts = new Hono<AppEnv>();
+
+// Every posts route requires a logged-in user who is a member of :blogId.
+posts.use('*', requireAuth, requireBlogMember);
+
+// Create a draft post: mint the blocks + the Post pointing at them, atomically (#20). A new post is
+// always a draft — publishing is a separate step, so it never lands on the public timeline by accident.
+posts.post('/', async (c) => {
+  const blogId = c.req.param('blogId')!;
+  const parsed = createSchema.safeParse(await parseBody(c));
+  if (!parsed.success) return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
+
+  const { content, Post } = c.var.models;
+  const postId = newPostId();
+  const blocks = parsed.data.blocks.map((block) => ({ contentId: newContentId(), block }));
+
+  const postItem = Post.create({
+    blogId,
+    postId,
+    type: parsed.data.type,
+    slug: parsed.data.slug,
+    status: 'draft',
+    content: { values: blocks.map((b) => b.contentId) },
+  }).params();
+
+  // ElectroDB `.params()` is loosely typed (Record<string, any>); it produces DocumentClient-shaped
+  // Put/Update params, so wrap it as a transact item for the store's typed write().
+  await content.write([
+    { Put: postItem } as TransactItem,
+    ...blocks.map((b) => content.putBlock(blogId, postId, b.contentId, b.block)),
+  ]);
+
+  return c.json({ post: await readPost(c, blogId, postId) }, 201);
+});
+
+// Admin listing, newest-first by created date (ls1). KEYS_ONLY LSI → query keys + BatchGet (see
+// listPosts). Metadata only — bodies aren't hydrated for a list.
+posts.get('/', async (c) => {
+  const blogId = c.req.param('blogId')!;
+  const data = await listPosts(c.var.models.Post, 'byCreated', blogId, { order: 'desc' });
+  return c.json({ posts: data.map((post) => postView(post, [])) });
+});
+
+posts.get('/:postId', async (c) => {
+  const post = await readPost(c, c.req.param('blogId')!, c.req.param('postId')!);
+  if (!post) return c.json({ error: 'not found' }, 404);
+  return c.json({ post });
+});
+
+// Edit: replace the whole body and/or the slug. Whole-body replace keeps the mutation simple for
+// short posts — delete the old blocks, put the new ones, and repoint content.values, all in one
+// TransactWrite so the list can never reference a missing block. (Per-block add/remove/reorder is
+// deferred to the long-form composer.)
+posts.patch('/:postId', async (c) => {
+  const blogId = c.req.param('blogId')!;
+  const postId = c.req.param('postId')!;
+  const { data: existing } = await c.var.models.Post.get({ blogId, postId }).go();
+  if (!existing) return c.json({ error: 'not found' }, 404);
+
+  const parsed = updateSchema.safeParse(await parseBody(c));
+  if (!parsed.success) return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
+
+  const { content, Post } = c.var.models;
+
+  if (parsed.data.blocks) {
+    const blocks = parsed.data.blocks.map((block) => ({ contentId: newContentId(), block }));
+    const patch = Post.patch({ blogId, postId })
+      .set({
+        content: { values: blocks.map((b) => b.contentId) },
+        ...(parsed.data.slug !== undefined ? { slug: parsed.data.slug } : {}),
+      })
+      .params();
+    await content.write([
+      { Update: patch } as TransactItem,
+      ...existing.content.values.map((id) => content.deleteBlock(blogId, postId, id)),
+      ...blocks.map((b) => content.putBlock(blogId, postId, b.contentId, b.block)),
+    ]);
+  } else if (parsed.data.slug !== undefined) {
+    await Post.patch({ blogId, postId }).set({ slug: parsed.data.slug }).go();
+  }
+
+  return c.json({ post: await readPost(c, blogId, postId) });
+});
+
+// Publish: set status + publishedAt, which populates ls3sk and puts the post on the public timeline.
+// A future publishedAt schedules it — the `ls3sk <= now` timeline query hides it until due (#21).
+posts.post('/:postId/publish', async (c) => {
+  const blogId = c.req.param('blogId')!;
+  const postId = c.req.param('postId')!;
+  const { data: existing } = await c.var.models.Post.get({ blogId, postId }).go();
+  if (!existing) return c.json({ error: 'not found' }, 404);
+
+  const parsed = publishSchema.safeParse(await parseBody(c));
+  if (!parsed.success) return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
+
+  const publishedAt = parsed.data?.publishedAt ?? new Date().toISOString();
+  await c.var.models.Post.patch({ blogId, postId }).set({ status: 'published', publishedAt }).go();
+
+  return c.json({ post: await readPost(c, blogId, postId) });
+});
+
+export const postsRoutes = new Hono<AppEnv>();
+postsRoutes.route('/admin/blogs/:blogId/posts', posts);

--- a/components/backend-api/routes/posts.ts
+++ b/components/backend-api/routes/posts.ts
@@ -3,10 +3,11 @@ import type { Context } from 'hono';
 import { z } from 'zod';
 import type { EntityItem } from 'electrodb';
 import type { AppEnv } from '../context';
+import type { Models } from '../models';
 import { listPosts, type PostEntity } from '../models/post';
 import { newPostId } from '../models/ids';
 import { blockSchema, newContentId, type StoredBlock } from '../content/blocks';
-import type { TransactItem } from '../content/store';
+import { isWriteConflict, type TransactItem } from '../content/store';
 import { requireAuth } from '../auth/middleware';
 import { requireBlogMember } from '../auth/blog';
 
@@ -56,6 +57,14 @@ const readPost = async (c: Context<AppEnv>, blogId: string, postId: string) => {
 
 const parseBody = async (c: Context<AppEnv>) => c.req.json().catch(() => undefined);
 
+// Per-blog slug uniqueness (PLAN.md 8): a PostSlug claim rides in the same transaction as the post.
+// `.create()`'s attribute_not_exists cancels the transaction if the slug is taken (→ 409); the claim
+// is released on slug change / delete. ElectroDB `.params()` is loosely typed, hence the casts.
+const claimSlug = (models: Models, blogId: string, slug: string, postId: string): TransactItem =>
+  ({ Put: models.PostSlug.create({ blogId, slug, postId }).params() }) as TransactItem;
+const releaseSlug = (models: Models, blogId: string, slug: string): TransactItem =>
+  ({ Delete: models.PostSlug.delete({ blogId, slug }).params() }) as TransactItem;
+
 const posts = new Hono<AppEnv>();
 
 // Every posts route requires a logged-in user who is a member of :blogId.
@@ -68,10 +77,13 @@ posts.post('/', async (c) => {
   const parsed = createSchema.safeParse(await parseBody(c));
   if (!parsed.success) return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
 
-  const { content, Post } = c.var.models;
+  const models = c.var.models;
+  const { content, Post } = models;
   const postId = newPostId();
   const blocks = parsed.data.blocks.map((block) => ({ contentId: newContentId(), block }));
 
+  // ElectroDB `.params()` is loosely typed (Record<string, any>); it produces DocumentClient-shaped
+  // Put/Update params, so wrap it as a transact item for the store's typed write().
   const postItem = Post.create({
     blogId,
     postId,
@@ -81,17 +93,23 @@ posts.post('/', async (c) => {
     content: { values: blocks.map((b) => b.contentId) },
   }).params();
 
-  // ElectroDB `.params()` is loosely typed (Record<string, any>); it produces DocumentClient-shaped
-  // Put/Update params, so wrap it as a transact item for the store's typed write().
-  await content.write([
+  const items: TransactItem[] = [
     { Put: postItem } as TransactItem,
     ...blocks.map((b) => content.putBlock(blogId, postId, b.contentId, b.block)),
-  ]);
+  ];
+  if (parsed.data.slug !== undefined) items.push(claimSlug(models, blogId, parsed.data.slug, postId));
+
+  try {
+    await content.write(items);
+  } catch (err) {
+    if (parsed.data.slug !== undefined && isWriteConflict(err)) return c.json({ error: 'slug already in use' }, 409);
+    throw err;
+  }
 
   return c.json({ post: await readPost(c, blogId, postId) }, 201);
 });
 
-// Admin listing, newest-first by created date (ls1). KEYS_ONLY LSI → query keys + BatchGet (see
+// Admin listing, newest-first by created date (ls1). KEYS_ONLY LSI hydrated by ElectroDB (see
 // listPosts). Metadata only — bodies aren't hydrated for a list.
 posts.get('/', async (c) => {
   const blogId = c.req.param('blogId')!;
@@ -105,36 +123,49 @@ posts.get('/:postId', async (c) => {
   return c.json({ post });
 });
 
-// Edit: replace the whole body and/or the slug. Whole-body replace keeps the mutation simple for
-// short posts — delete the old blocks, put the new ones, and repoint content.values, all in one
-// TransactWrite so the list can never reference a missing block. (Per-block add/remove/reorder is
+// Edit: replace the whole body and/or change the slug, in one TransactWrite. Whole-body replace keeps
+// the mutation simple for short posts — delete the old blocks, put the new ones, repoint
+// content.values — so the list can never reference a missing block. A slug change releases the old
+// claim and acquires the new one atomically (→ 409 if taken). (Per-block add/remove/reorder is
 // deferred to the long-form composer.)
 posts.patch('/:postId', async (c) => {
   const blogId = c.req.param('blogId')!;
   const postId = c.req.param('postId')!;
-  const { data: existing } = await c.var.models.Post.get({ blogId, postId }).go();
+  const models = c.var.models;
+  const { content, Post } = models;
+  const { data: existing } = await Post.get({ blogId, postId }).go();
   if (!existing) return c.json({ error: 'not found' }, 404);
 
   const parsed = updateSchema.safeParse(await parseBody(c));
   if (!parsed.success) return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
 
-  const { content, Post } = c.var.models;
+  const slugChanged = parsed.data.slug !== undefined && parsed.data.slug !== existing.slug;
+  const blocks = parsed.data.blocks?.map((block) => ({ contentId: newContentId(), block }));
 
-  if (parsed.data.blocks) {
-    const blocks = parsed.data.blocks.map((block) => ({ contentId: newContentId(), block }));
-    const patch = Post.patch({ blogId, postId })
-      .set({
-        content: { values: blocks.map((b) => b.contentId) },
-        ...(parsed.data.slug !== undefined ? { slug: parsed.data.slug } : {}),
-      })
-      .params();
-    await content.write([
-      { Update: patch } as TransactItem,
+  const set: { content?: { values: string[] }; slug?: string } = {};
+  if (blocks) set.content = { values: blocks.map((b) => b.contentId) };
+  if (slugChanged) set.slug = parsed.data.slug;
+
+  const items: TransactItem[] = [];
+  if (Object.keys(set).length) items.push({ Update: Post.patch({ blogId, postId }).set(set).params() } as TransactItem);
+  if (blocks) {
+    items.push(
       ...existing.content.values.map((id) => content.deleteBlock(blogId, postId, id)),
       ...blocks.map((b) => content.putBlock(blogId, postId, b.contentId, b.block)),
-    ]);
-  } else if (parsed.data.slug !== undefined) {
-    await Post.patch({ blogId, postId }).set({ slug: parsed.data.slug }).go();
+    );
+  }
+  if (slugChanged) {
+    if (existing.slug) items.push(releaseSlug(models, blogId, existing.slug));
+    items.push(claimSlug(models, blogId, parsed.data.slug!, postId));
+  }
+
+  if (items.length) {
+    try {
+      await content.write(items);
+    } catch (err) {
+      if (slugChanged && isWriteConflict(err)) return c.json({ error: 'slug already in use' }, 409);
+      throw err;
+    }
   }
 
   return c.json({ post: await readPost(c, blogId, postId) });
@@ -155,6 +186,38 @@ posts.post('/:postId/publish', async (c) => {
   await c.var.models.Post.patch({ blogId, postId }).set({ status: 'published', publishedAt }).go();
 
   return c.json({ post: await readPost(c, blogId, postId) });
+});
+
+// Unpublish: back to draft. Dropping publishedAt also clears ls3sk, so the post leaves the public
+// timeline (the inverse of publish). Re-publishing later stamps a fresh publishedAt.
+posts.post('/:postId/unpublish', async (c) => {
+  const blogId = c.req.param('blogId')!;
+  const postId = c.req.param('postId')!;
+  const { data: existing } = await c.var.models.Post.get({ blogId, postId }).go();
+  if (!existing) return c.json({ error: 'not found' }, 404);
+
+  await c.var.models.Post.patch({ blogId, postId }).set({ status: 'draft' }).remove(['publishedAt']).go();
+  return c.json({ post: await readPost(c, blogId, postId) });
+});
+
+// Delete: remove the post, all its content blocks, and its slug claim in one TransactWrite, so
+// nothing (blocks, or a slug claim blocking reuse) is left orphaned.
+posts.delete('/:postId', async (c) => {
+  const blogId = c.req.param('blogId')!;
+  const postId = c.req.param('postId')!;
+  const models = c.var.models;
+  const { content, Post } = models;
+  const { data: existing } = await Post.get({ blogId, postId }).go();
+  if (!existing) return c.json({ error: 'not found' }, 404);
+
+  const items: TransactItem[] = [
+    { Delete: Post.delete({ blogId, postId }).params() } as TransactItem,
+    ...existing.content.values.map((id) => content.deleteBlock(blogId, postId, id)),
+  ];
+  if (existing.slug) items.push(releaseSlug(models, blogId, existing.slug));
+
+  await content.write(items);
+  return c.body(null, 204);
 });
 
 export const postsRoutes = new Hono<AppEnv>();

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -235,11 +235,15 @@ Rules:
   across the GSI). Add `gs2`+ only if a new pattern demands it.
 - **Index projection is `KEYS_ONLY`** on every LSI/GSI, to keep indexes lean (minimal storage + write amplification).
   Implications:
-  - **GSI (`gs1`) queries return key fields only.** ElectroDB does not auto-hydrate — the read shape is **query `gs1` →
-    collect keys → `BatchGetItem` the base table**. Route this hydration through a **DataLoader** so N index hits
-    collapse into one batched round-trip.
-  - **LSI queries** can still request non-projected attributes; DynamoDB auto-fetches them from the base table at extra
-    RCU (no second round-trip). So LSIs cost RCU where GSIs cost a hydration call.
+  - **Both GSI and LSI queries return key fields only** — `KEYS_ONLY` is `KEYS_ONLY`. ElectroDB does not auto-hydrate,
+    and (verified against DynamoDB Local + ElectroDB 3.9 in v0.0.4) an LSI does **not** auto-fetch non-projected
+    attributes either: a plain query drops rows on the missing ownership stamp, and `{ ignoreOwnership: true }` returns
+    empty items — only `{ ignoreOwnership: true, data: 'includeKeys' }` surfaces the raw keys. So **every** KEYS_ONLY read
+    (gs1 or LSI) uses the same shape: **query index → collect keys → `BatchGetItem` the base table**.
+  - Route gs1 hydration through a **DataLoader** so N index hits collapse into one batched round-trip. LSI listings
+    (`models/post.ts` `listPosts`) query for ordered keys, slice the id out of the `sk`, then BatchGet and restore order.
+  - (An LSI *could* be given an `ALL`/`INCLUDE` projection to read attributes directly at extra RCU, but v1 keeps every
+    index `KEYS_ONLY` for lean writes and hydrates uniformly.)
 
 **Access patterns → index map.** The reads each index serves (all LSIs share `pk: BLOGS#{blogId}`; sparse — only items
 carrying that `ls*sk` appear):

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -235,15 +235,15 @@ Rules:
   across the GSI). Add `gs2`+ only if a new pattern demands it.
 - **Index projection is `KEYS_ONLY`** on every LSI/GSI, to keep indexes lean (minimal storage + write amplification).
   Implications:
-  - **Both GSI and LSI queries return key fields only** — `KEYS_ONLY` is `KEYS_ONLY`. ElectroDB does not auto-hydrate,
-    and (verified against DynamoDB Local + ElectroDB 3.9 in v0.0.4) an LSI does **not** auto-fetch non-projected
-    attributes either: a plain query drops rows on the missing ownership stamp, and `{ ignoreOwnership: true }` returns
-    empty items — only `{ ignoreOwnership: true, data: 'includeKeys' }` surfaces the raw keys. So **every** KEYS_ONLY read
-    (gs1 or LSI) uses the same shape: **query index → collect keys → `BatchGetItem` the base table**.
-  - Route gs1 hydration through a **DataLoader** so N index hits collapse into one batched round-trip. LSI listings
-    (`models/post.ts` `listPosts`) query for ordered keys, slice the id out of the `sk`, then BatchGet and restore order.
+  - **Both GSI and LSI queries return key fields only** — `KEYS_ONLY` is `KEYS_ONLY`. A plain read drops rows on the
+    missing ownership stamp; DynamoDB does **not** auto-fetch non-projected attributes for an LSI either (verified against
+    DynamoDB Local + ElectroDB 3.9 in v0.0.4). The read is always **query index → fetch full items from the base table**.
+  - **ElectroDB does the follow-on fetch for you** with `.go({ hydrate: true })`, returning full items in index order —
+    this is what `models/post.ts` `listPosts` uses for the timestamp LSIs. Under the hood you can also do it by hand
+    (`{ ignoreOwnership: true, data: 'includeKeys' }` → BatchGet), which is what the gs1 **DataLoader** does so that N
+    index hits collapse into a single batched `BatchGetItem` (hydrate would issue one fetch per query).
   - (An LSI *could* be given an `ALL`/`INCLUDE` projection to read attributes directly at extra RCU, but v1 keeps every
-    index `KEYS_ONLY` for lean writes and hydrates uniformly.)
+    index `KEYS_ONLY` for lean writes and hydrates on read.)
 
 **Access patterns → index map.** The reads each index serves (all LSIs share `pk: BLOGS#{blogId}`; sparse — only items
 carrying that `ls*sk` appear):


### PR DESCRIPTION
## v0.0.4 — Posts (backend)

Working state: **create/edit/publish a short post via the API.** Deploy → setup → log in → author a post. No infra change (Post reuses `ls1`/`ls2`/`ls3` + raw pk/sk).

### Data model
- **`models/post.ts`** — `Post` ElectroDB entity, `pk=BLOGS#{blogId}` / `sk=POSTS#{postId}` (shares the blog partition). LSIs `ls1`=createdAt, `ls2`=updatedAt, `ls3`=publishedAt. `ls3` is **sparse** — `publishedAt` is only set on publish, so drafts never land on the public-timeline index and a future `publishedAt` self-hides under a `<= now` query (#21).
- **`content/blocks.ts` + `content/store.ts`** — content blocks are hand-rolled, not ElectroDB (per 8.2): Zod discriminated-union on `type` (ships `PLAIN_TEXT`; new types slot into one array), raw pk/sk under `BLOGS#{blogId}#POSTS#{postId}#CONTENTS`, one query hydrates a whole body.

### Atomicity (#20)
Block writes travel with the parent `Post.content.values[]` in a single `@aws-sdk/lib-dynamodb` `TransactWriteCommand`. ElectroDB `.params()` returns plain-JS DocumentClient params that drop straight in as `{Put}`/`{Update}` beside the raw block items, so the ordered list can never drift from its blocks.

### Routes (`/admin/blogs/:blogId/posts`)
Gated by `requireAuth` + new `requireBlogMember` (MapBlogUser membership → attaches `role` for future gating). Create draft · list (by-created) · get+hydrate · PATCH (whole-body replace) · POST `/publish`.

### Notable: PLAN.md 8.1 correction
The plan claimed LSIs auto-fetch non-projected attributes. Verified empirically (DynamoDB Local + ElectroDB 3.9) that **KEYS_ONLY LSIs return keys only, exactly like GSIs** — no auto-fetch. So `listPosts` uses the same query-keys→BatchGet hydration as the gs1 loaders. PLAN.md 8.1 updated to match; v1 keeps every index `KEYS_ONLY` and hydrates uniformly.

### Deferred
Per-block add/remove/reorder (edit is whole-body replace; blocks capped at 25 to stay under TransactWrite's 100-item limit); additional block types.

### Tests
38/38 green — Post entity (defaults, sparse `ls3`, LSI listing), block schema, content store (transactional round-trip + delete), and the full posts HTTP flow (auth/membership 401·403, create, read, list, edit with no-orphan-blocks assertion, publish). `tsc --noEmit` clean; Lambda bundles.