### PR TITLE
feat: v0.0.5 public site — frontend-site, renderer, microblog theme

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,9 +27,30 @@
         "zod": "^4.0.0",
       },
     },
+    "components/frontend-site": {
+      "name": "@thatblog/frontend-site",
+      "version": "0.0.5",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.700.0",
+        "@thatblog/backend-api": "*",
+        "@thatblog/renderer": "*",
+        "hono": "^4.6.0",
+      },
+    },
+    "packages/renderer": {
+      "name": "@thatblog/renderer",
+      "version": "0.0.5",
+      "dependencies": {
+        "liquidjs": "^10.0.0",
+      },
+    },
   },
   "packages": {
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.16", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ=="],
+
     "@aws-sdk/client-dynamodb": ["@aws-sdk/client-dynamodb@3.1085.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/credential-provider-node": "^3.972.66", "@aws-sdk/dynamodb-codec": "^3.973.31", "@aws-sdk/middleware-endpoint-discovery": "^3.972.23", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-EpEFvJm+YjrCeDeXTQcbvk2zviLhKxM7exEiuAXXs4QT6h8HemeMY3gxF0S4gScjzhu3VdDXjLLnlJczIj/49w=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1085.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.16", "@aws-sdk/core": "^3.975.1", "@aws-sdk/credential-provider-node": "^3.972.66", "@aws-sdk/middleware-sdk-s3": "^3.972.62", "@aws-sdk/signature-v4-multi-region": "^3.996.39", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.975.1", "", { "dependencies": { "@aws-sdk/types": "^3.974.0", "@aws-sdk/xml-builder": "^3.972.34", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.2", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.0", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q=="],
 
@@ -56,6 +77,8 @@
     "@aws-sdk/lib-dynamodb": ["@aws-sdk/lib-dynamodb@3.1085.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/util-dynamodb": "^3.996.6", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-dynamodb": "^3.1085.0" } }, "sha512-S0ejNYEEb+uLUlZ9KF157dJVLMZqBelGyYlPOZBv82ChQ4uD2GK1XUaDsfFdzqXxdwCfYUtC/4n6/sE/vHgFlQ=="],
 
     "@aws-sdk/middleware-endpoint-discovery": ["@aws-sdk/middleware-endpoint-discovery@3.972.23", "", { "dependencies": { "@aws-sdk/endpoint-cache": "^3.972.9", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-FoEkpD2A8haYWNT4wp8zW1x0Hc+NyxcnKJ2Hf4jX8EI5R4ybo1LRI3ql7iuFX1MTyklZx9hum9dPkq6R46pQMw=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/signature-v4-multi-region": "^3.996.39", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw=="],
 
     "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.31", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/signature-v4-multi-region": "^3.996.39", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw=="],
 
@@ -221,6 +244,10 @@
 
     "@thatblog/backend-api": ["@thatblog/backend-api@workspace:components/backend-api"],
 
+    "@thatblog/frontend-site": ["@thatblog/frontend-site@workspace:components/frontend-site"],
+
+    "@thatblog/renderer": ["@thatblog/renderer@workspace:packages/renderer"],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -321,6 +348,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
     "compress-commons": ["compress-commons@6.0.2", "", { "dependencies": { "crc-32": "^1.2.0", "crc32-stream": "^6.0.0", "is-stream": "^2.0.1", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
@@ -408,6 +437,8 @@
     "jsonschema": ["jsonschema@1.5.0", "", {}, "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw=="],
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
+
+    "liquidjs": ["liquidjs@10.27.2", "", { "dependencies": { "commander": "^10.0.0" }, "bin": { "liquidjs": "bin/liquid.js", "liquid": "bin/liquid.js" } }, "sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 

--- a/components/backend-api/app.ts
+++ b/components/backend-api/app.ts
@@ -22,7 +22,7 @@ export function createApp(models: Models) {
     c.json({
       status: 'ok',
       service: 'backend-api',
-      version: '0.0.4',
+      version: '0.0.5',
     }),
   );
 

--- a/components/backend-api/models/blog-domain.ts
+++ b/components/backend-api/models/blog-domain.ts
@@ -32,8 +32,17 @@ export const blogDomainSchema = {
   },
 } as const;
 
-export const makeBlogDomain = (c: DynamoDBClient, table: string) =>
-  new Entity(blogDomainSchema, { client: c, table });
+export const makeBlogDomain = (c: DynamoDBClient, table: string) => new Entity(blogDomainSchema, { client: c, table });
 
 export const BlogDomain = makeBlogDomain(client, TABLE_NAME);
 export type BlogDomainEntity = ReturnType<typeof makeBlogDomain>;
+
+// Public routing (PLAN.md 8.1): host → blogId via the unique gs1. KEYS_ONLY projects nothing but the
+// keys, so query with includeKeys+ignoreOwnership ([[electrodb-keys-only-gsi]]) and read blogId back
+// out of gs1sk (BLOGS#{blogId}) — no follow-on fetch needed, the id is right there in the key. The
+// caller lowercases host first (keys are casing:'none', so the model does not normalise).
+export async function resolveHostToBlogId(entity: BlogDomainEntity, host: string): Promise<string | undefined> {
+  const { data } = await entity.query.byHost({ host }).go({ ignoreOwnership: true, data: 'includeKeys' });
+  const key = data[0] as unknown as { gs1sk?: string } | undefined;
+  return key?.gs1sk?.slice('BLOGS#'.length);
+}

--- a/components/backend-api/models/blog.ts
+++ b/components/backend-api/models/blog.ts
@@ -1,5 +1,5 @@
 import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { Entity } from 'electrodb';
+import { Entity, type EntityItem } from 'electrodb';
 import { client, TABLE_NAME } from './client';
 import { timestamps } from './_shared';
 
@@ -39,3 +39,4 @@ export const makeBlog = (c: DynamoDBClient, table: string) => new Entity(blogSch
 
 export const Blog = makeBlog(client, TABLE_NAME);
 export type BlogEntity = ReturnType<typeof makeBlog>;
+export type BlogItem = EntityItem<BlogEntity>;

--- a/components/backend-api/package.json
+++ b/components/backend-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thatblog/backend-api",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "main": "lambda.ts",

--- a/components/frontend-site/app.spec.ts
+++ b/components/frontend-site/app.spec.ts
@@ -1,0 +1,107 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { testModels } from '../../test/dynamo';
+import { createRenderer, fsLoader } from '@thatblog/renderer';
+import { newBlogId, newPostId } from '@thatblog/backend-api/models/ids';
+import { newContentId, type Block } from '@thatblog/backend-api/content/blocks';
+import { createApp } from './app';
+
+// The site renders the real shipped theme off disk (fsLoader) against a blog seeded straight into the
+// Testcontainers table — no setup flow (that's the backend-api spec's job; this file only ever touches
+// its own randomly-keyed blog, so the shared table stays conflict-free).
+const models = testModels();
+const themeRoot = fileURLToPath(new URL('../../themes/microblog', import.meta.url));
+const app = createApp({ models, renderer: createRenderer(fsLoader(themeRoot)) });
+
+const host = 'sitetest.example.com';
+const blogId = newBlogId();
+
+// A request as if it arrived for this blog's host (Host drives blog resolution).
+const visit = (path: string) => app.request(path, { headers: { host } });
+
+// Seed a post with a single PLAIN_TEXT block, wiring the block into content.values so the body
+// hydrates in order (PLAN.md 8.2). Optionally claim a slug so the /:slug route can resolve it.
+async function seedPost(opts: { status: 'draft' | 'published'; publishedAt?: string; text: string; slug?: string }) {
+  const postId = newPostId();
+  const contentId = newContentId();
+  const block: Block = { type: 'PLAIN_TEXT', value: opts.text };
+  await models.Post.create({
+    blogId,
+    postId,
+    status: opts.status,
+    publishedAt: opts.publishedAt,
+    slug: opts.slug,
+    content: { values: [contentId] },
+  }).go();
+  await models.content.write([models.content.putBlock(blogId, postId, contentId, block)]);
+  if (opts.slug) await models.PostSlug.create({ blogId, slug: opts.slug, postId }).go();
+  return postId;
+}
+
+const iso = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOString();
+
+let livePostId = '';
+let draftPostId = '';
+let scheduledPostId = '';
+
+beforeAll(async () => {
+  await models.Blog.create({ blogId, profile: { name: 'Site Test', bio: 'a test blog' } }).go();
+  await models.BlogDomain.create({ blogId, host, type: 'primary' }).go();
+  livePostId = await seedPost({
+    status: 'published',
+    publishedAt: iso(-1000),
+    text: 'hello from the timeline',
+    slug: 'hello-there',
+  });
+  draftPostId = await seedPost({ status: 'draft', text: 'still a draft' });
+  scheduledPostId = await seedPost({ status: 'published', publishedAt: iso(60_000), text: 'from the future' });
+});
+
+describe('frontend-site public routing', () => {
+  it('404s a request for an unknown host', async () => {
+    const res = await app.request('/', { headers: { host: 'nobody.example.com' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('renders the timeline with the profile and published post body', async () => {
+    const res = await visit('/');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Site Test');
+    expect(html).toContain('a test blog');
+    expect(html).toContain('hello from the timeline');
+    expect(html).toContain('href="/hello-there"'); // permalink uses the slug
+  });
+
+  it('hides drafts and scheduled posts from the timeline', async () => {
+    const html = await (await visit('/')).text();
+    expect(html).not.toContain('still a draft');
+    expect(html).not.toContain('from the future');
+  });
+});
+
+describe('frontend-site post detail', () => {
+  it('renders a published post by slug', async () => {
+    const res = await visit('/hello-there');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('hello from the timeline');
+  });
+
+  it('renders a published post by id', async () => {
+    const res = await visit(`/posts/${livePostId}`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('hello from the timeline');
+  });
+
+  it('404s a draft post', async () => {
+    expect((await visit(`/posts/${draftPostId}`)).status).toBe(404);
+  });
+
+  it('404s a scheduled (future) post', async () => {
+    expect((await visit(`/posts/${scheduledPostId}`)).status).toBe(404);
+  });
+
+  it('404s an unknown slug', async () => {
+    expect((await visit('/no-such-post')).status).toBe(404);
+  });
+});

--- a/components/frontend-site/app.ts
+++ b/components/frontend-site/app.ts
@@ -1,0 +1,40 @@
+import { Hono } from 'hono';
+import type { Models } from '@thatblog/backend-api/models';
+import { resolveHostToBlogId } from '@thatblog/backend-api/models/blog-domain';
+import type { Renderer } from '@thatblog/renderer';
+import type { SiteEnv } from './context';
+import { timeline } from './pages/timeline';
+import { postById, postBySlug } from './pages/post';
+
+// createApp takes its dependencies so tests can point the whole app at a Testcontainers table and a
+// local-disk theme (mirrors backend-api's createApp); lambda.ts binds the env-driven singletons + the
+// S3 theme loader. The wiring lives there, not here, so importing this module never eagerly builds the
+// S3 renderer (which needs CONTENT_BUCKET) — the tests import createApp with their own deps.
+export function createApp(deps: { models: Models; renderer: Renderer }) {
+  const app = new Hono<SiteEnv>();
+
+  app.use('*', async (c, next) => {
+    c.set('models', deps.models);
+    c.set('renderer', deps.renderer);
+    await next();
+  });
+
+  // Resolve the blog from the incoming Host (PLAN.md section 10): host → blogId via the unique
+  // DOMAINS# gs1, then load the Blog. Strip any port and lowercase — the domain keys are stored
+  // verbatim (casing:'none'), so routing normalises here. An unknown host is a 404, before any page.
+  app.use('*', async (c, next) => {
+    const host = (c.req.header('host') ?? '').split(':')[0]!.toLowerCase();
+    const blogId = host ? await resolveHostToBlogId(c.var.models.BlogDomain, host) : undefined;
+    const { data: blog } = blogId ? await c.var.models.Blog.get({ blogId }).go() : { data: undefined };
+    if (!blog) return c.notFound();
+    c.set('blog', blog);
+    await next();
+  });
+
+  app.get('/', timeline);
+  // Static-prefixed route before the slug catch-all so /posts/:postId can't be swallowed as a slug.
+  app.get('/posts/:postId', postById);
+  app.get('/:slug', postBySlug);
+
+  return app;
+}

--- a/components/frontend-site/context.ts
+++ b/components/frontend-site/context.ts
@@ -1,0 +1,14 @@
+import type { Models } from '@thatblog/backend-api/models';
+import type { BlogItem } from '@thatblog/backend-api/models/blog';
+import type { Renderer } from '@thatblog/renderer';
+
+// Hono per-request variables. `models`/`renderer` are set for every request by the app middleware;
+// `blog` is set only after resolveBlog (Host → Blog), so the page handlers behind it read it
+// non-optionally. A miss in resolveBlog 404s before any handler runs.
+export type SiteEnv = {
+  Variables: {
+    models: Models;
+    renderer: Renderer;
+    blog: BlogItem;
+  };
+};

--- a/components/frontend-site/lambda.ts
+++ b/components/frontend-site/lambda.ts
@@ -1,0 +1,10 @@
+import { handle } from 'hono/aws-lambda';
+import { client, makeModels, TABLE_NAME } from '@thatblog/backend-api/models';
+import { createApp } from './app';
+import { defaultRenderer } from './theme';
+
+// Bind the env-driven singletons + the S3-backed theme renderer for Lambda. Kept out of app.ts so the
+// unit tests can import createApp without CONTENT_BUCKET / an S3 client (they inject a local renderer).
+const app = createApp({ models: makeModels(client, TABLE_NAME), renderer: defaultRenderer() });
+
+export const handler = handle(app);

--- a/components/frontend-site/loaders/s3.ts
+++ b/components/frontend-site/loaders/s3.ts
@@ -1,0 +1,25 @@
+import { S3Client, GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import type { TemplateLoader } from '@thatblog/renderer';
+
+// The prod counterpart to renderer's fsLoader: theme templates live in the content bucket under a
+// per-theme prefix (PLAN.md #14). LiquidJS's own template cache means each partial is fetched from S3
+// once per warm container, then served from memory (PLAN.md section 9) — so this only issues S3 reads
+// on a cold container. It lives here, not in @thatblog/renderer, to keep that package AWS-SDK-free.
+export function s3Loader(client: S3Client, bucket: string, prefix: string): TemplateLoader {
+  const key = (path: string) => `${prefix}/${path}`;
+
+  return {
+    async readFile(path) {
+      const out = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key(path) }));
+      return out.Body!.transformToString();
+    },
+    async exists(path) {
+      try {
+        await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key(path) }));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}

--- a/components/frontend-site/package.json
+++ b/components/frontend-site/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@thatblog/frontend-site",
+  "version": "0.0.5",
+  "private": true,
+  "type": "module",
+  "main": "lambda.ts",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
+    "@thatblog/backend-api": "*",
+    "@thatblog/renderer": "*",
+    "hono": "^4.6.0"
+  }
+}

--- a/components/frontend-site/pages/post.ts
+++ b/components/frontend-site/pages/post.ts
@@ -1,0 +1,35 @@
+import type { Context } from 'hono';
+import type { Models } from '@thatblog/backend-api/models';
+import type { SiteEnv } from '../context';
+import { blogView, postView } from '../view';
+
+// A post is publicly visible only when published and its publishedAt has arrived — a draft (no
+// publishedAt) or a scheduled post (future publishedAt, #21) 404s on the public site, matching the
+// ls3sk <= now timeline filter. Returns the themed view model, or undefined when there's nothing live.
+export async function loadLivePost(models: Models, blogId: string, postId: string, now: string) {
+  const { data: post } = await models.Post.get({ blogId, postId }).go();
+  if (!post || post.status !== 'published' || !post.publishedAt || post.publishedAt > now) return undefined;
+  const stored = await models.content.listBlocks(blogId, postId);
+  return postView(post, stored);
+}
+
+// Post detail. Resolves a postId directly (/posts/:postId) or a slug via the PostSlug guard entity,
+// which doubles as the slug → post resolver (PLAN.md 8). Draft/scheduled/unknown all render as 404.
+async function renderPost(c: Context<SiteEnv>, postId: string) {
+  const { models, renderer, blog } = c.var;
+  const post = await loadLivePost(models, blog.blogId, postId, new Date().toISOString());
+  if (!post) return c.notFound();
+  const html = await renderer.render('post', { blog: blogView(blog), post, pageTitle: blog.profile.name });
+  return c.html(html);
+}
+
+export const postById = (c: Context<SiteEnv>) => renderPost(c, c.req.param('postId')!);
+
+export async function postBySlug(c: Context<SiteEnv>) {
+  const { data: claim } = await c.var.models.PostSlug.get({
+    blogId: c.var.blog.blogId,
+    slug: c.req.param('slug')!,
+  }).go();
+  if (!claim) return c.notFound();
+  return renderPost(c, claim.postId);
+}

--- a/components/frontend-site/pages/timeline.ts
+++ b/components/frontend-site/pages/timeline.ts
@@ -1,0 +1,23 @@
+import type { Context } from 'hono';
+import { listPosts } from '@thatblog/backend-api/models/post';
+import type { SiteEnv } from '../context';
+import { blogView, postView } from '../view';
+
+// The public timeline: a blog's published posts, newest-first. listPosts hydrates the KEYS_ONLY ls3
+// index ([[electrodb-keys-only-gsi]]); ls3 is sparse (only published posts carry publishedAt), and we
+// drop any with a future publishedAt so scheduled posts stay hidden until due (#21). Each post's body
+// is hydrated for the card — v0.0.4 posts are short; the excerpt-boundary optimisation (hydrate only
+// up to content.excerpt for long posts, PLAN.md 8.2) is deferred until article posts exist.
+export async function timeline(c: Context<SiteEnv>) {
+  const { models, renderer, blog } = c.var;
+  const now = new Date().toISOString();
+
+  const posts = await listPosts(models.Post, 'byPublished', blog.blogId, { order: 'desc' });
+  const live = posts.filter((p) => p.publishedAt && p.publishedAt <= now);
+  const cards = await Promise.all(
+    live.map(async (post) => postView(post, await models.content.listBlocks(blog.blogId, post.postId))),
+  );
+
+  const html = await renderer.render('timeline', { blog: blogView(blog), posts: cards, pageTitle: blog.profile.name });
+  return c.html(html);
+}

--- a/components/frontend-site/theme.ts
+++ b/components/frontend-site/theme.ts
@@ -1,0 +1,18 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { createRenderer, type Renderer } from '@thatblog/renderer';
+import { s3Loader } from './loaders/s3';
+
+// The one shipped theme (PLAN.md section 9). Per-blog theme install/activation is deferred to 0.1.6,
+// so v0.0.5 renders every blog from the catalog copy synced at deploy (themes/ → themes/_catalog/,
+// see infra/deploy.sh) rather than a blog's own themes/{blogId}/ prefix. When the Theme entity lands,
+// this prefix becomes `themes/${blogId}/${blog.activeThemeId}`.
+export const DEFAULT_THEME = 'microblog';
+
+// A single renderer for the warm container: all blogs share the catalog theme in v0.0.5, and LiquidJS
+// caches parsed templates on the instance, so building one at module load keeps cold-start S3 reads to
+// a minimum. CONTENT_BUCKET is injected by SAM (infra/template.yaml).
+export function defaultRenderer(): Renderer {
+  const bucket = process.env.CONTENT_BUCKET;
+  if (!bucket) throw new Error('CONTENT_BUCKET is not set');
+  return createRenderer(s3Loader(new S3Client({}), bucket, `themes/_catalog/${DEFAULT_THEME}`));
+}

--- a/components/frontend-site/view.ts
+++ b/components/frontend-site/view.ts
@@ -1,0 +1,37 @@
+import type { BlogItem } from '@thatblog/backend-api/models/blog';
+import type { PostItem } from '@thatblog/backend-api/models/post';
+import type { StoredBlock } from '@thatblog/backend-api/content/blocks';
+
+// The view models the theme renders. Kept deliberately flat and free of key/plumbing fields so a
+// theme author sees a clean, stable shape (PLAN.md section 9) — the same fixtures back the theme-kit.
+
+export const blogView = (blog: BlogItem) => ({
+  blogId: blog.blogId,
+  name: blog.profile.name,
+  bio: blog.profile.bio,
+  avatar: blog.profile.avatar,
+  cover: blog.profile.cover,
+  location: blog.profile.location,
+  website: blog.profile.website,
+});
+
+// A post's public URL: the pretty slug when it has one, else the always-addressable postId path (slug
+// generation is deferred, so a slugless post is still viewable). Both routes render the post page.
+export const postUrl = (post: Pick<PostItem, 'slug' | 'postId'>): string =>
+  post.slug ? `/${post.slug}` : `/posts/${post.postId}`;
+
+// A post plus its body, blocks ordered by the parent's content.values[] (order is the array order,
+// not DynamoDB sk order — PLAN.md 8.2). Drops the raw content.values / key fields.
+export const postView = (post: PostItem, stored: StoredBlock[]) => {
+  const byId = new Map(stored.map((b) => [b.contentId, b]));
+  const blocks = post.content.values.map((id) => byId.get(id)).filter((b): b is StoredBlock => Boolean(b));
+  return {
+    postId: post.postId,
+    type: post.type,
+    slug: post.slug,
+    url: postUrl(post),
+    publishedAt: post.publishedAt,
+    pinned: post.pinned,
+    blocks,
+  };
+};

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -18,8 +18,8 @@ echo "==> Region: $REGION"
 echo "==> Installing dependencies"
 (cd "$ROOT" && bun install)
 
-echo "==> Building backend-api"
-(cd "$ROOT" && bun run build:api)
+echo "==> Building Lambdas (backend-api + frontend-site)"
+(cd "$ROOT" && bun run build)
 
 echo "==> Deploying stack: $STACK_NAME"
 sam deploy \
@@ -31,11 +31,23 @@ sam deploy \
   --no-fail-on-empty-changeset
 
 echo "==> Reading stack outputs"
-API_URL="$(aws cloudformation describe-stacks \
-  --stack-name "$STACK_NAME" \
+outputs() {
+  aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" \
+    --output text
+}
+API_URL="$(outputs ApiUrl)"
+CONTENT_BUCKET="$(outputs ContentBucketName)"
+
+# Sync the shipped themes to the catalog prefix the site renders from (PLAN.md section 12). Per-blog
+# theme copies (themes/{blogId}/) are a runtime op (0.1.6); v0.0.5 renders straight from _catalog.
+echo "==> Syncing themes to s3://${CONTENT_BUCKET}/themes/_catalog/"
+aws s3 sync "$ROOT/themes/" "s3://${CONTENT_BUCKET}/themes/_catalog/" \
   --region "$REGION" \
-  --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
-  --output text)"
+  --delete \
+  --exclude '*/node_modules/*'
 
 echo "==> Health check: ${API_URL}/health"
 curl -fsS "${API_URL}/health"

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: thatblog - multi-tenant serverless blog platform (0.0.1 foundation)
+Description: thatblog - multi-tenant serverless blog platform (0.0.5 public site)
 
 Globals:
   Function:
@@ -112,6 +112,9 @@ Resources:
     Properties:
       StageName: $default
 
+  # backend-api owns the JSON API surfaces: /health, /auth/*, /admin/* (setup, authoring; later the
+  # admin SPA). It no longer sits on the catch-all — the public site does. HTTP API routes the most
+  # specific match, so /admin/{proxy+} beats the site's /{proxy+} and /health beats it as an exact key.
   BackendApiFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -122,6 +125,40 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref Table
         - S3CrudPolicy:
+            BucketName: !Ref ContentBucket
+      Events:
+        Health:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /health
+            Method: ANY
+        Auth:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /auth/{proxy+}
+            Method: ANY
+        Admin:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /admin/{proxy+}
+            Method: ANY
+
+  # frontend-site: Hono SSR of the active theme (via @thatblog/renderer + the S3 theme loader). Resolves
+  # the blog from the incoming Host (PLAN.md section 10) and serves the public pages, so it takes the
+  # root + catch-all. Read-only on the table; reads theme templates from the content bucket.
+  FrontendSiteFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-frontend-site'
+      CodeUri: dist/frontend-site
+      Handler: lambda.handler
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref Table
+        - S3ReadPolicy:
             BucketName: !Ref ContentBucket
       Events:
         Root:

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "thatblog",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "workspaces": ["components/*", "packages/*", "themes/*"],
   "scripts": {
-    "build": "bun run build:api",
+    "build": "bun run build:api && bun run build:site",
     "build:api": "bun build ./components/backend-api/lambda.ts --target=node --format=cjs --outdir=infra/dist/backend-api --sourcemap=linked",
+    "build:site": "bun build ./components/frontend-site/lambda.ts --target=node --format=cjs --outdir=infra/dist/frontend-site --sourcemap=linked",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/renderer/index.ts
+++ b/packages/renderer/index.ts
@@ -1,0 +1,38 @@
+import { Liquid } from 'liquidjs';
+import { toLiquidFS } from './liquid-fs';
+
+// @thatblog/renderer wraps LiquidJS behind a tiny, source-agnostic loader so the exact same render
+// path runs in prod (templates from S3) and in the theme-kit / tests (templates from local disk) —
+// "works in theme-kit" therefore implies "works in prod" (PLAN.md section 9). This package is the one
+// piece meant to be genuinely standalone (PLAN.md #6): its only dependency is LiquidJS. The S3 loader
+// lives in frontend-site, which already carries the AWS SDK — here we ship just the node-fs loader.
+
+// A template source, reduced to the two operations LiquidJS actually needs. `path` is always a
+// template-relative posix path the renderer composed (e.g. `timeline.liquid`, `partials/post-card.liquid`);
+// a loader maps it onto its backing store (a directory, an S3 prefix, …).
+export interface TemplateLoader {
+  readFile(path: string): Promise<string>;
+  exists(path: string): Promise<boolean>;
+}
+
+export interface Renderer {
+  // Render a theme template by name (no extension) with a view model, returning the HTML string.
+  render(template: string, data: Record<string, unknown>): Promise<string>;
+}
+
+// Build a renderer over a loader. LiquidJS owns template parsing + its own warm-container template
+// cache; we only hand it a virtual filesystem (toLiquidFS) pointed at the loader. `.liquid` extension
+// and a single virtual root ('.') keep template names clean (`timeline`, `partials/post-card`).
+export function createRenderer(loader: TemplateLoader): Renderer {
+  const engine = new Liquid({
+    fs: toLiquidFS(loader),
+    root: ['.'],
+    extname: '.liquid',
+  });
+
+  return {
+    render: (template, data) => engine.renderFile(template, data),
+  };
+}
+
+export { fsLoader } from './loaders/fs';

--- a/packages/renderer/liquid-fs.ts
+++ b/packages/renderer/liquid-fs.ts
@@ -1,0 +1,28 @@
+import { posix } from 'node:path';
+import type { FS } from 'liquidjs';
+import type { TemplateLoader } from './index';
+
+// Adapt a TemplateLoader onto the LiquidJS `FS` interface. LiquidJS drives lookups through `resolve`
+// (compose a lookup path from a dir + template name + extension) then `readFile`/`exists`; we route
+// those to the loader. Everything is posix + async — the loaders (a directory, an S3 prefix) are flat
+// key spaces, so there is no realpath containment to enforce (omitting `contains` = assumed contained).
+// The sync methods are mandated by the type but only used by `renderSync`, which we never call, so
+// they throw rather than pretend: this renderer is async-only (S3 has no sync read).
+export function toLiquidFS(loader: TemplateLoader): FS {
+  const notSync = () => {
+    throw new Error('renderer: synchronous rendering is not supported');
+  };
+
+  return {
+    resolve(dir, file, ext) {
+      const rel = posix.join(dir === '.' ? '' : dir, file);
+      return ext && !rel.endsWith(ext) ? rel + ext : rel;
+    },
+    dirname: (file) => posix.dirname(file),
+    sep: '/',
+    exists: (path) => loader.exists(path),
+    readFile: (path) => loader.readFile(path),
+    existsSync: notSync,
+    readFileSync: notSync,
+  };
+}

--- a/packages/renderer/loaders/fs.ts
+++ b/packages/renderer/loaders/fs.ts
@@ -1,0 +1,21 @@
+import { readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { TemplateLoader } from '../index';
+
+// The local-disk loader: templates live under a directory (a theme folder in the repo, or the
+// theme-kit working dir). The prod counterpart is frontend-site's S3 loader — same interface, so the
+// renderer can't tell them apart. `path` is a template-relative posix path composed by the renderer;
+// join() maps it onto the root directory.
+export function fsLoader(root: string): TemplateLoader {
+  return {
+    readFile: (path) => readFile(join(root, path), 'utf8'),
+    async exists(path) {
+      try {
+        await access(join(root, path));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@thatblog/renderer",
+  "version": "0.0.5",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+    "liquidjs": "^10.0.0"
+  }
+}

--- a/packages/renderer/renderer.spec.ts
+++ b/packages/renderer/renderer.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createRenderer, type TemplateLoader } from './index';
+
+// An in-memory loader keeps the renderer test independent of any theme on disk: it exercises the
+// LiquidJS wiring (layout, partials, filters, missing-template errors) against a fixed template map.
+const memoryLoader = (files: Record<string, string>): TemplateLoader => ({
+  readFile: async (path) => {
+    const src = files[path];
+    if (src === undefined) throw new Error(`ENOENT: ${path}`);
+    return src;
+  },
+  exists: async (path) => path in files,
+});
+
+describe('createRenderer', () => {
+  it('renders a template with its view model', async () => {
+    const renderer = createRenderer(memoryLoader({ 'hello.liquid': 'Hi {{ name }}' }));
+    expect(await renderer.render('hello', { name: 'James' })).toBe('Hi James');
+  });
+
+  it('resolves a layout and a nested partial through the loader', async () => {
+    const renderer = createRenderer(
+      memoryLoader({
+        'layout.liquid': '<main>{% block content %}{% endblock %}</main>',
+        'page.liquid':
+          "{% layout 'layout' %}{% block content %}{% render 'partials/card', title: title %}{% endblock %}",
+        'partials/card.liquid': '<h1>{{ title }}</h1>',
+      }),
+    );
+    expect(await renderer.render('page', { title: 'Post' })).toBe('<main><h1>Post</h1></main>');
+  });
+
+  it('surfaces a missing template as an error', async () => {
+    const renderer = createRenderer(memoryLoader({}));
+    await expect(renderer.render('nope', {})).rejects.toThrow();
+  });
+});

--- a/themes/microblog/layout.liquid
+++ b/themes/microblog/layout.liquid
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ pageTitle | default: blog.name | escape }}</title>
+    <style>
+      :root { --fg: #0f1419; --muted: #536471; --accent: #1d9bf0; --line: #eff3f4; }
+      * { box-sizing: border-box; }
+      body { margin: 0; font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--fg); }
+      .container { max-width: 600px; margin: 0 auto; border-left: 1px solid var(--line); border-right: 1px solid var(--line); min-height: 100vh; }
+      .cover { height: 200px; background: var(--line) center / cover no-repeat; }
+      .profile { padding: 16px; border-bottom: 1px solid var(--line); }
+      .profile .avatar { width: 80px; height: 80px; border-radius: 50%; object-fit: cover; margin-top: -56px; border: 4px solid #fff; background: var(--line); display: block; }
+      .profile h1 { margin: 12px 0 2px; font-size: 20px; }
+      .profile .bio { margin: 8px 0; }
+      .profile .meta { color: var(--muted); font-size: 15px; }
+      .profile .meta a { color: var(--accent); text-decoration: none; }
+      a.permalink { color: inherit; text-decoration: none; }
+      .post { padding: 16px; border-bottom: 1px solid var(--line); display: block; }
+      .post:hover { background: #f7f9f9; }
+      .post .badges { color: var(--muted); font-size: 13px; text-transform: uppercase; letter-spacing: .04em; }
+      .post .body { margin: 6px 0; }
+      .post time { color: var(--muted); font-size: 14px; }
+      .empty { padding: 40px 16px; color: var(--muted); text-align: center; }
+      footer { padding: 24px 16px; color: var(--muted); font-size: 13px; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="cover" {% if blog.cover %}style="background-image: url('{{ blog.cover | escape }}')"{% endif %}></div>
+      <header class="profile">
+        {% if blog.avatar %}<img class="avatar" src="{{ blog.avatar | escape }}" alt="{{ blog.name | escape }}" />{% else %}<span class="avatar"></span>{% endif %}
+        <h1><a class="permalink" href="/">{{ blog.name | escape }}</a></h1>
+        {% if blog.bio %}<p class="bio">{{ blog.bio | escape | newline_to_br }}</p>{% endif %}
+        <p class="meta">
+          {% if blog.location %}<span>{{ blog.location | escape }}</span>{% endif %}
+          {% if blog.website %}<a href="{{ blog.website | escape }}" rel="me">{{ blog.website | escape }}</a>{% endif %}
+        </p>
+      </header>
+      {% block content %}{% endblock %}
+      <footer>Powered by thatblog</footer>
+    </div>
+  </body>
+</html>

--- a/themes/microblog/partials/blocks.liquid
+++ b/themes/microblog/partials/blocks.liquid
@@ -1,0 +1,10 @@
+{%- comment -%}
+  Render a post body: one output per content block, switching on the discriminated-union `type`
+  (PLAN.md 8.2). v0.0.4 ships PLAIN_TEXT only; new block types (MEDIA, LINK, …) add a `when` branch
+  here as the union grows. Unknown types are skipped rather than rendered as garbage.
+{%- endcomment -%}
+{%- for block in blocks -%}
+  {%- case block.type -%}
+    {%- when 'PLAIN_TEXT' -%}<p>{{ block.value | escape | newline_to_br }}</p>
+  {%- endcase -%}
+{%- endfor -%}

--- a/themes/microblog/partials/post-card.liquid
+++ b/themes/microblog/partials/post-card.liquid
@@ -1,0 +1,9 @@
+{%- comment -%} A single post as it appears in the timeline: badges, body, and a permalink to its page. {%- endcomment -%}
+<a class="post permalink" href="{{ post.url }}">
+  <div class="badges">
+    {%- if post.pinned %}Pinned · {% endif -%}
+    {{ post.type }}
+  </div>
+  <div class="body">{% render 'partials/blocks', blocks: post.blocks %}</div>
+  <time datetime="{{ post.publishedAt }}">{{ post.publishedAt | date: '%b %-d, %Y' }}</time>
+</a>

--- a/themes/microblog/post.liquid
+++ b/themes/microblog/post.liquid
@@ -1,0 +1,11 @@
+{% layout 'layout' %}
+{% block content %}
+  <article class="post">
+    <div class="badges">
+      {%- if post.pinned %}Pinned · {% endif -%}
+      {{ post.type }}
+    </div>
+    <div class="body">{% render 'partials/blocks', blocks: post.blocks %}</div>
+    <time datetime="{{ post.publishedAt }}">{{ post.publishedAt | date: '%b %-d, %Y' }}</time>
+  </article>
+{% endblock %}

--- a/themes/microblog/theme.json
+++ b/themes/microblog/theme.json
@@ -1,0 +1,6 @@
+{
+  "name": "Microblog",
+  "version": "1.0.0",
+  "engine": "liquid",
+  "description": "A Twitter-like microblog theme: profile header, timeline, and post detail."
+}

--- a/themes/microblog/timeline.liquid
+++ b/themes/microblog/timeline.liquid
@@ -1,0 +1,8 @@
+{% layout 'layout' %}
+{% block content %}
+  {% if posts.size > 0 %}
+    {% for post in posts %}{% render 'partials/post-card', post: post %}{% endfor %}
+  {% else %}
+    <p class="empty">No posts yet.</p>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Public-facing site for a blog: `Host`-resolved SSR of a shipped theme (plan milestone 0.0.5). Visit a blog → see its timeline and posts.

## What's new

**`packages/renderer` (`@thatblog/renderer`)** — standalone LiquidJS wrapper (its only dep is LiquidJS, per plan #6). `createRenderer(loader)` over a minimal `TemplateLoader` interface (`readFile`/`exists`), an async-only adapter onto LiquidJS's `FS`, and a node `fsLoader(root)` for tests/theme-kit.

**`themes/microblog`** — the shipped Twitter-like theme: profile header + cover, timeline, post detail, and a `case`-on-`type` block partial (PLAIN_TEXT today; new block types add a branch). All user text is escaped.

**`components/frontend-site` (`@thatblog/frontend-site`)** — Hono SSR. Resolves the blog from the incoming `Host` (404 on miss); timeline lists published, non-scheduled posts newest-first; post detail by `/:slug` (PostSlug resolver) or `/posts/:postId`, with drafts/scheduled/unknown all 404ing. The S3 theme loader lives here to keep the renderer AWS-free; the default app is wired in `lambda.ts` so importing `app.ts` in tests needs no `CONTENT_BUCKET`.

**backend-api** — `resolveHostToBlogId` (host→blog via the unique `gs1`, same KEYS_ONLY pattern as `userByEmail`) + a `BlogItem` type export.

**infra** — `FrontendSiteFunction` (DynamoDB read-only + S3 read) takes `/` and `/{proxy+}`; backend-api moves off the catch-all onto explicit `/health` + `/auth/*` + `/admin/*` (HTTP API most-specific-match wins). `build:site` added; `deploy.sh` builds both Lambdas and syncs `themes/` → the `_catalog` prefix.

## Notes / deferred

- The site renders every blog from the catalog theme (`themes/_catalog/microblog`); per-blog theme install/activation is a 0.1.6 concern.
- Post URLs fall back to `/posts/{id}` when a post has no slug (slug generation still deferred).
- On a real deploy the site resolves only when the visited `Host` matches a `BlogDomain` — the raw execute-api URL won't (custom domains are 0.1.x). Tests set `Host` explicitly.
- Timeline hydrates full short-post bodies; the excerpt-boundary optimisation and RSS are deferred.

## Testing

- `tsc --noEmit` clean; **55/55** unit tests pass (8 new frontend-site cases: routing, publish-gating, slug + id detail).
- Both Lambdas bundle; prettier clean.