### PR TITLE
feat: admin SPA (v0.0.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@ node_modules/
 infra/dist/
 components/frontend-admin/dist/
 .aws-sam/
+.claude/
 *.log
 .DS_Store
 .env
 .env.*
 .envrc
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 infra/dist/
+components/frontend-admin/dist/
 .aws-sam/
 *.log
 .DS_Store

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "components/backend-api": {
       "name": "@thatblog/backend-api",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.700.0",
         "@aws-sdk/lib-dynamodb": "^3.700.0",
@@ -25,6 +25,20 @@
         "hono": "^4.6.0",
         "nanoid": "^5.0.0",
         "zod": "^4.0.0",
+      },
+    },
+    "components/frontend-admin": {
+      "name": "@thatblog/frontend-admin",
+      "version": "0.0.6",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "vite": "^6.0.0",
       },
     },
     "components/frontend-site": {
@@ -94,59 +108,97 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
@@ -154,7 +206,15 @@
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
@@ -179,6 +239,8 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.2", "", { "os": "android", "cpu": "arm" }, "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="],
 
@@ -244,9 +306,19 @@
 
     "@thatblog/backend-api": ["@thatblog/backend-api@workspace:components/backend-api"],
 
+    "@thatblog/frontend-admin": ["@thatblog/frontend-admin@workspace:components/frontend-admin"],
+
     "@thatblog/frontend-site": ["@thatblog/frontend-site@workspace:components/frontend-site"],
 
     "@thatblog/renderer": ["@thatblog/renderer@workspace:packages/renderer"],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -262,9 +334,15 @@
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
     "@types/ssh2": ["@types/ssh2@0.5.52", "", { "dependencies": { "@types/node": "*", "@types/ssh2-streams": "*" } }, "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg=="],
 
     "@types/ssh2-streams": ["@types/ssh2-streams@0.1.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w=="],
 
@@ -314,6 +392,8 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
+
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
     "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
@@ -323,6 +403,8 @@
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
+
+    "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -335,6 +417,8 @@
     "byline": ["byline@5.0.0", "", {}, "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001805", "", {}, "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA=="],
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
@@ -352,6 +436,8 @@
 
     "compress-commons": ["compress-commons@6.0.2", "", { "dependencies": { "crc-32": "^1.2.0", "crc32-stream": "^6.0.0", "is-stream": "^2.0.1", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg=="],
 
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
@@ -361,6 +447,8 @@
     "crc32-stream": ["crc32-stream@6.0.0", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "dataloader": ["dataloader@2.2.3", "", {}, "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="],
 
@@ -378,13 +466,15 @@
 
     "electrodb": ["electrodb@3.9.1", "", { "dependencies": { "@aws-sdk/lib-dynamodb": "^3.654.0", "@aws-sdk/util-dynamodb": "^3.654.0", "jsonschema": "1.5.0" } }, "sha512-Z1y19yQWuZq0pI7kmDfzMbSzTAImCHLqjmTCML1kYHuSSvK+yZZYY2RyDAefpe2xJ0RkGTmFjuH4y/AWL1nJPQ=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.389", "", {}, "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
-    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -407,6 +497,8 @@
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -434,6 +526,10 @@
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
     "jsonschema": ["jsonschema@1.5.0", "", {}, "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw=="],
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
@@ -448,7 +544,7 @@
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -467,6 +563,8 @@
     "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
 
     "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+
+    "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -504,6 +602,12 @@
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
@@ -517,6 +621,10 @@
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -586,9 +694,11 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+    "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
@@ -606,6 +716,8 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
@@ -615,6 +727,8 @@
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
@@ -638,7 +752,13 @@
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "postcss/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "vite-node/vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "vitest/vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -652,6 +772,114 @@
 
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "vite-node/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
     "dockerode/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "vite-node/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
   }
 }

--- a/components/backend-api/app.spec.ts
+++ b/components/backend-api/app.spec.ts
@@ -18,7 +18,7 @@ const json = (body: unknown) => ({
 // The one cookie in Set-Cookie, as a `name=value` pair ready to send back as a Cookie header.
 const cookieFrom = (res: Response): string => (res.headers.get('set-cookie') ?? '').split(';')[0] ?? '';
 
-const login = (email: string, password: string) => app.request('/auth/login', json({ email, password }));
+const login = (email: string, password: string) => app.request('/api/auth/login', json({ email, password }));
 
 // Captured by setup and reused by the posts flow below (setup is one-shot, so these describes share
 // the one owner + blog the run creates).
@@ -37,7 +37,7 @@ describe('backend-api auth flow', () => {
     const system = await ensureSystem(models);
     expect(system.setupKey).toBeTruthy();
 
-    const res = await app.request(`/admin/setup/${system.setupKey}`, json(creds));
+    const res = await app.request(`/api/setup/${system.setupKey}`, json(creds));
     expect(res.status).toBe(201);
 
     const body = (await res.json()) as { user: { email: string }; blog: { blogId: string } };
@@ -50,14 +50,14 @@ describe('backend-api auth flow', () => {
   });
 
   it('serves the authenticated user from the setup auto-login cookie', async () => {
-    const res = await app.request('/auth/me', { headers: { cookie: setupCookie } });
+    const res = await app.request('/api/auth/me', { headers: { cookie: setupCookie } });
     expect(res.status).toBe(200);
     expect(((await res.json()) as { user: { email: string } }).user.email).toBe('owner@example.com');
   });
 
   it('rejects a wrong setup key with 404, then 410 once the key is cleared', async () => {
     // Key is already cleared by the successful setup above, so every call is now 410.
-    const res = await app.request('/admin/setup/whatever', json({}));
+    const res = await app.request('/api/setup/whatever', json({}));
     expect(res.status).toBe(410);
   });
 
@@ -66,27 +66,38 @@ describe('backend-api auth flow', () => {
     expect(res.status).toBe(401);
   });
 
-  it('logs in case-insensitively and round-trips /auth/me', async () => {
+  it('logs in case-insensitively and round-trips /api/auth/me', async () => {
     const res = await login('OWNER@EXAMPLE.COM', creds.password);
     expect(res.status).toBe(200);
 
-    const me = await app.request('/auth/me', { headers: { cookie: cookieFrom(res) } });
+    const me = await app.request('/api/auth/me', { headers: { cookie: cookieFrom(res) } });
     expect(me.status).toBe(200);
   });
 
-  it('rejects /auth/me without a cookie', async () => {
-    const res = await app.request('/auth/me');
+  it('rejects /api/auth/me without a cookie', async () => {
+    const res = await app.request('/api/auth/me');
     expect(res.status).toBe(401);
   });
 
   it('revokes the session on logout', async () => {
     const cookie = cookieFrom(await login(creds.email, creds.password));
 
-    const out = await app.request('/auth/logout', { method: 'POST', headers: { cookie } });
+    const out = await app.request('/api/auth/logout', { method: 'POST', headers: { cookie } });
     expect(out.status).toBe(200);
 
-    const me = await app.request('/auth/me', { headers: { cookie } });
+    const me = await app.request('/api/auth/me', { headers: { cookie } });
     expect(me.status).toBe(401); // session record deleted
+  });
+
+  it("lists the user's blogs for the admin SPA", async () => {
+    const res = await app.request('/api/blogs', { headers: { cookie: setupCookie } });
+    expect(res.status).toBe(200);
+    const { blogs } = (await res.json()) as { blogs: { blogId: string; name: string; role: string }[] };
+    expect(blogs).toEqual([{ blogId, name: 'My Blog', role: 'owner' }]);
+  });
+
+  it('rejects /api/blogs without a cookie', async () => {
+    expect((await app.request('/api/blogs')).status).toBe(401);
   });
 });
 
@@ -113,21 +124,21 @@ describe('backend-api posts flow', () => {
 
   it('rejects authoring without a session', async () => {
     const res = await app.request(
-      `/admin/blogs/${blogId}/posts`,
+      `/api/blogs/${blogId}/posts`,
       json({ blocks: [{ type: 'PLAIN_TEXT', value: 'hi' }] }),
     );
     expect(res.status).toBe(401);
   });
 
   it('rejects authoring on a blog the user is not a member of', async () => {
-    const res = await authedJson('/admin/blogs/bNOTMINE/posts', 'POST', {
+    const res = await authedJson('/api/blogs/bNOTMINE/posts', 'POST', {
       blocks: [{ type: 'PLAIN_TEXT', value: 'hi' }],
     });
     expect(res.status).toBe(403);
   });
 
   it('creates a draft short post with its block', async () => {
-    const res = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+    const res = await authedJson(`/api/blogs/${blogId}/posts`, 'POST', {
       blocks: [{ type: 'PLAIN_TEXT', value: 'my first post' }],
     });
     expect(res.status).toBe(201);
@@ -141,21 +152,21 @@ describe('backend-api posts flow', () => {
   });
 
   it('reads the post back with its body in order', async () => {
-    const res = await app.request(`/admin/blogs/${blogId}/posts/${postId}`, { headers: { cookie: setupCookie } });
+    const res = await app.request(`/api/blogs/${blogId}/posts/${postId}`, { headers: { cookie: setupCookie } });
     expect(res.status).toBe(200);
     const { post } = (await res.json()) as PostBody;
     expect(post.blocks[0]?.value).toBe('my first post');
   });
 
   it("lists the blog's posts", async () => {
-    const res = await app.request(`/admin/blogs/${blogId}/posts`, { headers: { cookie: setupCookie } });
+    const res = await app.request(`/api/blogs/${blogId}/posts`, { headers: { cookie: setupCookie } });
     expect(res.status).toBe(200);
     const { posts } = (await res.json()) as { posts: { postId: string }[] };
     expect(posts.map((p) => p.postId)).toContain(postId);
   });
 
   it('replaces the whole body on edit, leaving no stale blocks', async () => {
-    const res = await authedJson(`/admin/blogs/${blogId}/posts/${postId}`, 'PATCH', {
+    const res = await authedJson(`/api/blogs/${blogId}/posts/${postId}`, 'PATCH', {
       blocks: [{ type: 'PLAIN_TEXT', value: 'edited' }],
     });
     expect(res.status).toBe(200);
@@ -170,7 +181,7 @@ describe('backend-api posts flow', () => {
   });
 
   it('publishes the post, stamping publishedAt', async () => {
-    const res = await authedJson(`/admin/blogs/${blogId}/posts/${postId}/publish`, 'POST', {});
+    const res = await authedJson(`/api/blogs/${blogId}/posts/${postId}/publish`, 'POST', {});
     expect(res.status).toBe(200);
     const { post } = (await res.json()) as PostBody;
     expect(post.status).toBe('published');
@@ -182,7 +193,7 @@ describe('backend-api posts flow', () => {
   });
 
   it('unpublishes back to draft, clearing publishedAt and leaving the public timeline', async () => {
-    const res = await authedJson(`/admin/blogs/${blogId}/posts/${postId}/unpublish`, 'POST', {});
+    const res = await authedJson(`/api/blogs/${blogId}/posts/${postId}/unpublish`, 'POST', {});
     expect(res.status).toBe(200);
     const { post } = (await res.json()) as PostBody;
     expect(post.status).toBe('draft');
@@ -194,14 +205,14 @@ describe('backend-api posts flow', () => {
   });
 
   it('enforces per-blog slug uniqueness with a 409', async () => {
-    const first = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+    const first = await authedJson(`/api/blogs/${blogId}/posts`, 'POST', {
       slug: 'hello-world',
       blocks: [{ type: 'PLAIN_TEXT', value: 'has a slug' }],
     });
     expect(first.status).toBe(201);
     expect(((await first.json()) as PostBody).post.slug).toBe('hello-world');
 
-    const clash = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+    const clash = await authedJson(`/api/blogs/${blogId}/posts`, 'POST', {
       slug: 'hello-world',
       blocks: [{ type: 'PLAIN_TEXT', value: 'wants the same slug' }],
     });
@@ -209,22 +220,22 @@ describe('backend-api posts flow', () => {
   });
 
   it('deletes a post with its blocks and frees the slug', async () => {
-    const created = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+    const created = await authedJson(`/api/blogs/${blogId}/posts`, 'POST', {
       slug: 'delete-me',
       blocks: [{ type: 'PLAIN_TEXT', value: 'temporary' }],
     });
     const { post } = (await created.json()) as PostBody;
 
-    const del = await authedJson(`/admin/blogs/${blogId}/posts/${post.postId}`, 'DELETE', {});
+    const del = await authedJson(`/api/blogs/${blogId}/posts/${post.postId}`, 'DELETE', {});
     expect(del.status).toBe(204);
 
     // Gone: the post 404s and its blocks are swept.
-    const get = await app.request(`/admin/blogs/${blogId}/posts/${post.postId}`, { headers: { cookie: setupCookie } });
+    const get = await app.request(`/api/blogs/${blogId}/posts/${post.postId}`, { headers: { cookie: setupCookie } });
     expect(get.status).toBe(404);
     expect(await models.content.listBlocks(blogId, post.postId)).toHaveLength(0);
 
     // The slug claim was released, so it can be reused.
-    const reuse = await authedJson(`/admin/blogs/${blogId}/posts`, 'POST', {
+    const reuse = await authedJson(`/api/blogs/${blogId}/posts`, 'POST', {
       slug: 'delete-me',
       blocks: [{ type: 'PLAIN_TEXT', value: 'reused slug' }],
     });

--- a/components/backend-api/app.ts
+++ b/components/backend-api/app.ts
@@ -19,7 +19,7 @@ export function createApp(models: Models) {
     await next();
   });
 
-  app.get('/health', (c) =>
+  app.get('/api/health', (c) =>
     c.json({
       status: 'ok',
       service: 'backend-api',

--- a/components/backend-api/app.ts
+++ b/components/backend-api/app.ts
@@ -4,6 +4,7 @@ import { makeLoaders } from './loaders';
 import type { AppEnv } from './context';
 import { setupRoutes } from './routes/setup';
 import { authRoutes } from './routes/auth';
+import { blogsRoutes } from './routes/blogs';
 import { postsRoutes } from './routes/posts';
 
 // createApp takes the model set so tests can point the whole app at a Testcontainers table (mirrors
@@ -22,12 +23,13 @@ export function createApp(models: Models) {
     c.json({
       status: 'ok',
       service: 'backend-api',
-      version: '0.0.5',
+      version: '0.0.6',
     }),
   );
 
   app.route('/', setupRoutes);
   app.route('/', authRoutes);
+  app.route('/', blogsRoutes);
   app.route('/', postsRoutes);
 
   return app;

--- a/components/backend-api/auth/system.ts
+++ b/components/backend-api/auth/system.ts
@@ -19,7 +19,7 @@ export async function ensureSystem(models: Models): Promise<SystemItem> {
   const setupKey = newSetupKey();
   try {
     const { data } = await models.System.create({ sessionSecrets: [newSecret()], setupKey }).go();
-    console.log(`[thatblog] first-run setup required — POST /admin/setup/${setupKey}`);
+    console.log(`[thatblog] first-run setup required — POST /api/setup/${setupKey}`);
     return data;
   } catch (err) {
     // Lost a create race with a concurrent cold start; the winner's row is now present.

--- a/components/backend-api/models/client.ts
+++ b/components/backend-api/models/client.ts
@@ -1,8 +1,12 @@
+import assert from 'node:assert';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 
-// Table name is injected by SAM (infra/template.yaml → TABLE_NAME env). The fallback keeps
-// imports safe outside Lambda (tests build their own client + table via makeModels()).
-export const TABLE_NAME = process.env.TABLE_NAME ?? 'thatblog';
+// Table name is injected by SAM (infra/template.yaml → TABLE_NAME env) — required, no default, so a
+// misconfigured Lambda fails fast at cold start rather than silently reading the wrong table. Tests
+// set TABLE_NAME via vitest.config (they build their own client + table via makeModels()).
+const tableName = process.env.TABLE_NAME;
+assert(tableName, 'TABLE_NAME env var is required');
+export const TABLE_NAME = tableName;
 
 // In Lambda the region + credentials come from the execution environment. DYNAMO_ENDPOINT lets
 // local dev point at a DynamoDB endpoint; unit tests don't use this singleton (see models/index.ts).

--- a/components/backend-api/models/client.ts
+++ b/components/backend-api/models/client.ts
@@ -2,7 +2,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 
 // Table name is injected by SAM (infra/template.yaml → TABLE_NAME env). The fallback keeps
 // imports safe outside Lambda (tests build their own client + table via makeModels()).
-export const TABLE_NAME = process.env.TABLE_NAME ?? 'thatblog-table';
+export const TABLE_NAME = process.env.TABLE_NAME ?? 'thatblog';
 
 // In Lambda the region + credentials come from the execution environment. DYNAMO_ENDPOINT lets
 // local dev point at a DynamoDB endpoint; unit tests don't use this singleton (see models/index.ts).

--- a/components/backend-api/routes/auth.ts
+++ b/components/backend-api/routes/auth.ts
@@ -26,7 +26,7 @@ export const authRoutes = new Hono<AppEnv>();
 // Email/password login (PLAN.md 10.1). Look the user up by email via the gs1 DataLoader, verify the
 // bcrypt hash, then mint a session cookie. A missing user and a bad password return the same 401 so
 // the endpoint doesn't reveal which emails exist.
-authRoutes.post('/auth/login', async (c) => {
+authRoutes.post('/api/auth/login', async (c) => {
   const body = await c.req.json().catch(() => undefined);
   const parsed = loginSchema.safeParse(body);
   if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
@@ -43,10 +43,10 @@ authRoutes.post('/auth/login', async (c) => {
 });
 
 // Current session's user — the round-trip that proves the cookie works.
-authRoutes.get('/auth/me', requireAuth, (c) => c.json({ user: publicUser(c.var.user) }));
+authRoutes.get('/api/auth/me', requireAuth, (c) => c.json({ user: publicUser(c.var.user) }));
 
 // Revoke the session (delete the record) and clear the cookie.
-authRoutes.post('/auth/logout', requireAuth, async (c) => {
+authRoutes.post('/api/auth/logout', requireAuth, async (c) => {
   await destroySession(c.var.models, c.var.user.userId, c.var.session.sessionId);
   clearSessionCookie(c);
   return c.json({ ok: true });

--- a/components/backend-api/routes/blogs.ts
+++ b/components/backend-api/routes/blogs.ts
@@ -1,0 +1,23 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../context';
+import { requireAuth } from '../auth/middleware';
+
+// The blogs the authenticated user belongs to — the admin SPA calls this on load to discover which
+// blog(s) it can write to (today there's one; a multi-blog picker is a future add, PLAN.md section 9).
+// MapBlogUser's gs1 (byUser: USERS#{userId} → BLOGS#{blogId}) is KEYS_ONLY, so hydrate the membership
+// items to read each role ([[electrodb-keys-only-gsi]]), then BatchGet the Blog items for their names.
+export const blogsRoutes = new Hono<AppEnv>();
+
+blogsRoutes.get('/api/blogs', requireAuth, async (c) => {
+  const { MapBlogUser, Blog } = c.var.models;
+
+  const { data: memberships } = await MapBlogUser.query.byUser({ userId: c.var.user.userId }).go({ hydrate: true });
+  if (!memberships.length) return c.json({ blogs: [] });
+
+  const { data: blogs } = await Blog.get(memberships.map((m) => ({ blogId: m.blogId }))).go();
+  const nameById = new Map(blogs.map((b) => [b.blogId, b.profile.name]));
+
+  return c.json({
+    blogs: memberships.map((m) => ({ blogId: m.blogId, name: nameById.get(m.blogId) ?? '', role: m.role })),
+  });
+});

--- a/components/backend-api/routes/posts.ts
+++ b/components/backend-api/routes/posts.ts
@@ -221,4 +221,4 @@ posts.delete('/:postId', async (c) => {
 });
 
 export const postsRoutes = new Hono<AppEnv>();
-postsRoutes.route('/admin/blogs/:blogId/posts', posts);
+postsRoutes.route('/api/blogs/:blogId/posts', posts);

--- a/components/backend-api/routes/setup.ts
+++ b/components/backend-api/routes/setup.ts
@@ -22,7 +22,7 @@ const setupSchema = z.object({
 
 export const setupRoutes = new Hono<AppEnv>();
 
-setupRoutes.post('/admin/setup/:key', async (c) => {
+setupRoutes.post('/api/setup/:key', async (c) => {
   const models = c.var.models;
   const system = await ensureSystem(models);
 

--- a/components/frontend-admin/index.html
+++ b/components/frontend-admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>thatblog admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/components/frontend-admin/package.json
+++ b/components/frontend-admin/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@thatblog/frontend-admin",
+  "version": "0.0.6",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/components/frontend-admin/src/App.tsx
+++ b/components/frontend-admin/src/App.tsx
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api, ApiError, type Blog, type Post, type User } from './api';
+
+const MAX_CHARS = 300; // short-post limit (PLAN.md section 14 — the inline composer)
+
+type Session = { user: User; blog: Blog };
+
+export function App() {
+  const [session, setSession] = useState<Session | undefined>();
+  const [loading, setLoading] = useState(true);
+
+  // On load, prove the cookie (me) and discover the blog to write to (blogs). A 401 just means
+  // "not logged in" → fall through to the login screen; anything else surfaces.
+  const refresh = useCallback(async () => {
+    try {
+      const [{ user }, { blogs }] = await Promise.all([api.me(), api.blogs()]);
+      setSession(blogs[0] ? { user, blog: blogs[0] } : undefined);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) setSession(undefined);
+      else throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (loading) return <main className="center">Loading…</main>;
+  if (!session) return <Login onLoggedIn={refresh} />;
+  return <Dashboard session={session} onLogout={() => setSession(undefined)} />;
+}
+
+function Login({ onLoggedIn }: { onLoggedIn: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError('');
+    try {
+      await api.login(email, password);
+      onLoggedIn();
+    } catch {
+      setError('Invalid email or password.');
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="center">
+      <form className="card" onSubmit={submit}>
+        <h1>thatblog</h1>
+        <input type="email" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <p className="error">{error}</p>}
+        <button type="submit" disabled={busy}>
+          {busy ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </main>
+  );
+}
+
+function Dashboard({ session, onLogout }: { session: Session; onLogout: () => void }) {
+  const { user, blog } = session;
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  const loadPosts = useCallback(async () => {
+    setPosts((await api.listPosts(blog.blogId)).posts);
+  }, [blog.blogId]);
+
+  useEffect(() => {
+    void loadPosts();
+  }, [loadPosts]);
+
+  async function logout() {
+    await api.logout();
+    onLogout();
+  }
+
+  return (
+    <main className="dashboard">
+      <header>
+        <h1>{blog.name}</h1>
+        <div className="who">
+          <span>{user.displayName ?? user.email}</span>
+          <button className="link" onClick={logout}>
+            Sign out
+          </button>
+        </div>
+      </header>
+      <Composer blogId={blog.blogId} onPosted={loadPosts} />
+      <PostList posts={posts} />
+    </main>
+  );
+}
+
+function Composer({ blogId, onPosted }: { blogId: string; onPosted: () => void }) {
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const remaining = MAX_CHARS - value.length;
+  const canPost = value.trim().length > 0 && remaining >= 0 && !busy;
+
+  // "Save draft" creates the post; "Publish" creates it then publishes (two calls — the API keeps
+  // create and publish as separate steps so a draft never hits the public timeline by accident).
+  async function submit(publish: boolean) {
+    setBusy(true);
+    setError('');
+    try {
+      const { post } = await api.createPost(blogId, value.trim());
+      if (publish) await api.publishPost(blogId, post.postId);
+      setValue('');
+      onPosted();
+    } catch {
+      setError('Could not save. Try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="composer">
+      <textarea
+        placeholder="What's happening?"
+        value={value}
+        maxLength={MAX_CHARS}
+        rows={4}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <div className="composer-actions">
+        <span className={remaining < 20 ? 'count low' : 'count'}>{remaining}</span>
+        <button className="secondary" disabled={!canPost} onClick={() => submit(false)}>
+          Save draft
+        </button>
+        <button disabled={!canPost} onClick={() => submit(true)}>
+          Publish
+        </button>
+      </div>
+      {error && <p className="error">{error}</p>}
+    </section>
+  );
+}
+
+function PostList({ posts }: { posts: Post[] }) {
+  if (!posts.length) return <p className="empty">No posts yet — write your first above.</p>;
+  return (
+    <ul className="posts">
+      {posts.map((post) => (
+        <li key={post.postId}>
+          <span className={`badge ${post.status}`}>{post.status}</span>
+          <span className="slug">{post.slug ?? post.postId}</span>
+          <time>{new Date(post.publishedAt ?? post.createdAt).toLocaleString()}</time>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/frontend-admin/src/api.ts
+++ b/components/frontend-admin/src/api.ts
@@ -1,0 +1,50 @@
+// Thin client over the backend-api JSON surface (served from the same origin under /api, PLAN.md #2).
+// credentials:'include' sends the signed session cookie the API issues on login. Any non-2xx throws an
+// ApiError carrying the status so callers can branch (401 → show login) without parsing bodies twice.
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    credentials: 'include',
+    headers: init?.body ? { 'content-type': 'application/json' } : undefined,
+    ...init,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => undefined)) as { error?: string } | undefined;
+    throw new ApiError(res.status, body?.error ?? res.statusText);
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export type User = { userId: string; email: string; displayName?: string };
+export type Blog = { blogId: string; name: string; role: string };
+export type Post = {
+  postId: string;
+  slug?: string;
+  status: 'draft' | 'published';
+  publishedAt?: string;
+  createdAt: string;
+};
+
+export const api = {
+  me: () => request<{ user: User }>('/auth/me'),
+  login: (email: string, password: string) =>
+    request<{ user: User }>('/auth/login', { method: 'POST', body: JSON.stringify({ email, password }) }),
+  logout: () => request<{ ok: true }>('/auth/logout', { method: 'POST' }),
+  blogs: () => request<{ blogs: Blog[] }>('/blogs'),
+  listPosts: (blogId: string) => request<{ posts: Post[] }>(`/blogs/${blogId}/posts`),
+  createPost: (blogId: string, value: string) =>
+    request<{ post: Post }>(`/blogs/${blogId}/posts`, {
+      method: 'POST',
+      body: JSON.stringify({ type: 'short', blocks: [{ type: 'PLAIN_TEXT', value }] }),
+    }),
+  publishPost: (blogId: string, postId: string) =>
+    request<{ post: Post }>(`/blogs/${blogId}/posts/${postId}/publish`, { method: 'POST', body: '{}' }),
+};

--- a/components/frontend-admin/src/main.tsx
+++ b/components/frontend-admin/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/components/frontend-admin/src/styles.css
+++ b/components/frontend-admin/src/styles.css
@@ -1,0 +1,170 @@
+:root {
+  --bg: #f5f8fa;
+  --card: #fff;
+  --border: #e1e8ed;
+  --text: #14171a;
+  --muted: #657786;
+  --brand: #1da1f2;
+  --draft: #f0b429;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-weight: 600;
+  background: var(--brand);
+  color: #fff;
+}
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+button.secondary {
+  background: transparent;
+  color: var(--brand);
+  border: 1px solid var(--brand);
+}
+button.link {
+  background: none;
+  color: var(--muted);
+  padding: 0;
+}
+
+.center {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 320px;
+  padding: 2rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+.card h1 {
+  margin: 0 0 0.5rem;
+  text-align: center;
+}
+.card input {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+.dashboard {
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+}
+.dashboard header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.dashboard header h1 {
+  margin: 0;
+}
+.who {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.composer {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+.composer textarea {
+  width: 100%;
+  border: none;
+  resize: vertical;
+  font-size: 1.1rem;
+  font-family: inherit;
+  outline: none;
+}
+.composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+.count {
+  margin-right: auto;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.count.low {
+  color: #e0245e;
+}
+
+.posts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.posts li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.slug {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.posts time {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+.badge {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+  background: var(--brand);
+}
+.badge.draft {
+  background: var(--draft);
+}
+
+.empty {
+  color: var(--muted);
+  text-align: center;
+  padding: 2rem 0;
+}
+.error {
+  color: #e0245e;
+  margin: 0;
+  font-size: 0.9rem;
+}

--- a/components/frontend-admin/tsconfig.json
+++ b/components/frontend-admin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/components/frontend-admin/vite.config.ts
+++ b/components/frontend-admin/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Served under /admin (PLAN.md #17), so assets must resolve from that prefix — base rewrites every
+// built asset URL to /admin/…. The build output (dist/) is synced to s3://…/admin/ by deploy.sh.
+export default defineConfig({
+  base: '/admin/',
+  plugins: [react()],
+  build: { outDir: 'dist', emptyOutDir: true },
+});

--- a/components/frontend-site/app.spec.ts
+++ b/components/frontend-site/app.spec.ts
@@ -11,7 +11,12 @@ import { createApp } from './app';
 // its own randomly-keyed blog, so the shared table stays conflict-free).
 const models = testModels();
 const themeRoot = fileURLToPath(new URL('../../themes/microblog', import.meta.url));
-const app = createApp({ models, renderer: createRenderer(fsLoader(themeRoot)) });
+const ADMIN_INDEX = '<!doctype html><title>thatblog admin</title>';
+const app = createApp({
+  models,
+  renderer: createRenderer(fsLoader(themeRoot)),
+  adminIndex: async () => ADMIN_INDEX,
+});
 
 const host = 'sitetest.example.com';
 const blogId = newBlogId();
@@ -79,11 +84,12 @@ describe('frontend-site public routing', () => {
     expect(html).not.toContain('from the future');
   });
 
-  it('redirects a bare /admin to the SPA entrypoint without needing a resolved host', async () => {
-    // No Host header → host resolution would 404, so this proves the redirect runs ahead of it.
+  it('serves the admin SPA index at a bare /admin without needing a resolved host', async () => {
+    // No Host header → host resolution would 404, so this proves /admin runs ahead of it.
     const res = await app.request('/admin');
-    expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toBe('/admin/index.html');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    expect(await res.text()).toBe(ADMIN_INDEX);
   });
 });
 

--- a/components/frontend-site/app.spec.ts
+++ b/components/frontend-site/app.spec.ts
@@ -78,6 +78,13 @@ describe('frontend-site public routing', () => {
     expect(html).not.toContain('still a draft');
     expect(html).not.toContain('from the future');
   });
+
+  it('redirects a bare /admin to the SPA entrypoint without needing a resolved host', async () => {
+    // No Host header → host resolution would 404, so this proves the redirect runs ahead of it.
+    const res = await app.request('/admin');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/admin/index.html');
+  });
 });
 
 describe('frontend-site post detail', () => {

--- a/components/frontend-site/app.ts
+++ b/components/frontend-site/app.ts
@@ -10,15 +10,15 @@ import { postById, postBySlug } from './pages/post';
 // local-disk theme (mirrors backend-api's createApp); lambda.ts binds the env-driven singletons + the
 // S3 theme loader. The wiring lives there, not here, so importing this module never eagerly builds the
 // S3 renderer (which needs CONTENT_BUCKET) — the tests import createApp with their own deps.
-export function createApp(deps: { models: Models; renderer: Renderer }) {
+export function createApp(deps: { models: Models; renderer: Renderer; adminIndex: () => Promise<string> }) {
   const app = new Hono<SiteEnv>();
 
-  // The admin SPA is served from S3 under /admin/* (HTTP API S3 proxy, PLAN.md #17). A bare /admin has
-  // no path segment for that route's {proxy+} to catch, so it falls through to this catch-all site app;
-  // send it on to the SPA entrypoint. It's /admin/index.html, not /admin/ — HTTP API normalises a
-  // trailing slash back to /admin, which would loop straight back here. This sits ahead of the
-  // host-resolution middleware because the admin build is global, not blog-scoped.
-  app.get('/admin', (c) => c.redirect('/admin/index.html', 302));
+  // The admin SPA's hashed assets are served from S3 under /admin/* (HTTP API S3 proxy, PLAN.md #17),
+  // but a bare /admin has no path segment for that route's {proxy+} to catch, so it falls through to
+  // this catch-all site app. Serve the SPA's entry HTML (admin/index.html, read from the content
+  // bucket) inline, so /admin stays a clean URL and its absolute /admin/assets/… then load from S3.
+  // This sits ahead of the host-resolution middleware because the admin build is global, not blog-scoped.
+  app.get('/admin', async (c) => c.html(await deps.adminIndex()));
 
   app.use('*', async (c, next) => {
     c.set('models', deps.models);

--- a/components/frontend-site/app.ts
+++ b/components/frontend-site/app.ts
@@ -13,6 +13,13 @@ import { postById, postBySlug } from './pages/post';
 export function createApp(deps: { models: Models; renderer: Renderer }) {
   const app = new Hono<SiteEnv>();
 
+  // The admin SPA is served from S3 under /admin/* (HTTP API S3 proxy, PLAN.md #17). A bare /admin has
+  // no path segment for that route's {proxy+} to catch, so it falls through to this catch-all site app;
+  // send it on to the SPA entrypoint. It's /admin/index.html, not /admin/ — HTTP API normalises a
+  // trailing slash back to /admin, which would loop straight back here. This sits ahead of the
+  // host-resolution middleware because the admin build is global, not blog-scoped.
+  app.get('/admin', (c) => c.redirect('/admin/index.html', 302));
+
   app.use('*', async (c, next) => {
     c.set('models', deps.models);
     c.set('renderer', deps.renderer);

--- a/components/frontend-site/assets.ts
+++ b/components/frontend-site/assets.ts
@@ -1,0 +1,15 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { s3Loader } from './loaders/s3';
+
+// The admin SPA's entry HTML lives in the content bucket at admin/index.html (synced by deploy.sh).
+// frontend-site serves it at /admin — the bare path the S3 proxy's /admin/{proxy+} route can't catch
+// (no segment for the greedy var) — so the browser gets the app on a clean /admin URL, and its hashed
+// assets then load straight from S3 via /admin/{proxy+}. Reuses s3Loader (readFile) scoped to admin/.
+// CONTENT_BUCKET is injected by SAM (infra/template.yaml). Kept out of app.ts so the tests inject a
+// fake index without an S3 client (mirrors defaultRenderer / theme.ts).
+export function adminIndexHtml(): () => Promise<string> {
+  const bucket = process.env.CONTENT_BUCKET;
+  if (!bucket) throw new Error('CONTENT_BUCKET is not set');
+  const loader = s3Loader(new S3Client({}), bucket, 'admin');
+  return () => loader.readFile('index.html');
+}

--- a/components/frontend-site/lambda.ts
+++ b/components/frontend-site/lambda.ts
@@ -2,9 +2,15 @@ import { handle } from 'hono/aws-lambda';
 import { client, makeModels, TABLE_NAME } from '@thatblog/backend-api/models';
 import { createApp } from './app';
 import { defaultRenderer } from './theme';
+import { adminIndexHtml } from './assets';
 
-// Bind the env-driven singletons + the S3-backed theme renderer for Lambda. Kept out of app.ts so the
-// unit tests can import createApp without CONTENT_BUCKET / an S3 client (they inject a local renderer).
-const app = createApp({ models: makeModels(client, TABLE_NAME), renderer: defaultRenderer() });
+// Bind the env-driven singletons + the S3-backed theme renderer + admin-index reader for Lambda. Kept
+// out of app.ts so the unit tests can import createApp without CONTENT_BUCKET / an S3 client (they
+// inject a local renderer and a fake admin index).
+const app = createApp({
+  models: makeModels(client, TABLE_NAME),
+  renderer: defaultRenderer(),
+  adminIndex: adminIndexHtml(),
+});
 
 export const handler = handle(app);

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -18,7 +18,7 @@ echo "==> Region: $REGION"
 echo "==> Installing dependencies"
 (cd "$ROOT" && bun install)
 
-echo "==> Building Lambdas (backend-api + frontend-site)"
+echo "==> Building Lambdas (backend-api + frontend-site) + admin SPA"
 (cd "$ROOT" && bun run build)
 
 echo "==> Deploying stack: $STACK_NAME"
@@ -48,6 +48,13 @@ aws s3 sync "$ROOT/themes/" "s3://${CONTENT_BUCKET}/themes/_catalog/" \
   --region "$REGION" \
   --delete \
   --exclude '*/node_modules/*'
+
+# Sync the admin SPA (one global build serves every blog) to the /admin prefix the HTTP API's S3
+# proxy serves from (PLAN.md #17, section 12). --delete clears stale hashed assets from prior builds.
+echo "==> Syncing admin SPA to s3://${CONTENT_BUCKET}/admin/"
+aws s3 sync "$ROOT/components/frontend-admin/dist/" "s3://${CONTENT_BUCKET}/admin/" \
+  --region "$REGION" \
+  --delete
 
 echo "==> Health check: ${API_URL}/health"
 curl -fsS "${API_URL}/health"

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -38,7 +38,7 @@ outputs() {
     --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" \
     --output text
 }
-API_URL="$(outputs ApiUrl)"
+BASE_URL="$(outputs Url)"
 CONTENT_BUCKET="$(outputs ContentBucketName)"
 
 # Sync the shipped themes to the catalog prefix the site renders from (PLAN.md section 12). Per-blog
@@ -56,7 +56,7 @@ aws s3 sync "$ROOT/components/frontend-admin/dist/" "s3://${CONTENT_BUCKET}/admi
   --region "$REGION" \
   --delete
 
-echo "==> Health check: ${API_URL}/health"
-curl -fsS "${API_URL}/health"
+echo "==> Health check: ${BASE_URL}/api/health"
+curl -fsS "${BASE_URL}/api/health"
 echo
-echo "==> Deployed. API: ${API_URL}"
+echo "==> Deployed. Site: ${BASE_URL}  API: ${BASE_URL}/api  Admin: ${BASE_URL}/admin"

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -175,7 +175,7 @@ Resources:
       ApiId: !Ref HttpApi
       IntegrationType: HTTP_PROXY
       IntegrationMethod: GET
-      IntegrationUri: !Sub 'http://${ContentBucket}.s3-website-${AWS::Region}.amazonaws.com/admin/{proxy}'
+      IntegrationUri: !Sub '${ContentBucket.WebsiteURL}/admin/{proxy}'
       PayloadFormatVersion: '1.0'
 
   AdminAssetsRoute:

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -171,15 +171,16 @@ Resources:
 
   # The admin SPA is static assets, so /admin/* is an HTTP-proxy integration straight to the content
   # bucket's public static-website endpoint — no Lambda in the asset path (plan #17). Two integrations
-  # because their target URIs differ: the greedy route forwards the captured {proxy} path, while bare
-  # /admin has no path var so it points straight at admin/index.html (the SPA entrypoint).
+  # because their target URIs differ: the greedy route forwards the captured path via the {proxy}
+  # URI path variable (bare braces, matched by name to the route's {proxy+} — HTTP API syntax, not
+  # ${request.path.proxy}); bare /admin has no path var so it points straight at admin/index.html.
   AdminAssetsIntegration:
     Type: AWS::ApiGatewayV2::Integration
     Properties:
       ApiId: !Ref HttpApi
       IntegrationType: HTTP_PROXY
       IntegrationMethod: GET
-      IntegrationUri: !Sub 'http://${ContentBucket}.s3-website-${AWS::Region}.amazonaws.com/admin/${!request.path.proxy}'
+      IntegrationUri: !Sub 'http://${ContentBucket}.s3-website-${AWS::Region}.amazonaws.com/admin/{proxy}'
       PayloadFormatVersion: '1.0'
 
   AdminRootIntegration:

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -167,8 +167,8 @@ Resources:
   # bucket's public static-website endpoint — no Lambda in the asset path (plan #17). The greedy route
   # forwards the captured path via the {proxy} URI path variable (bare braces, matched by name to the
   # route's {proxy+} — HTTP API syntax, not ${request.path.proxy}). A bare /admin has no path segment
-  # for {proxy+} to catch, so it falls through to /{proxy+} → frontend-site, which redirects it to the
-  # SPA entrypoint (see components/frontend-site/app.ts).
+  # for {proxy+} to catch, so it falls through to /{proxy+} → frontend-site, which serves the SPA's
+  # admin/index.html (read from this bucket) inline (see components/frontend-site/app.ts).
   AdminAssetsIntegration:
     Type: AWS::ApiGatewayV2::Integration
     Properties:

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -106,11 +106,30 @@ Resources:
             Action: s3:GetObject
             Resource: !Sub '${ContentBucket.Arn}/*'
 
-  # Single HTTP API front door (plan #2). $default stage = no stage suffix on the URL.
+  # Single HTTP API front door (plan #2). Defined raw (not AWS::Serverless::HttpApi) with NO OpenAPI
+  # Body: a Body-defined API owns its whole route set, which silently drops standalone
+  # AWS::ApiGatewayV2::Route resources (the reason the /admin S3 route wouldn't deploy). With no Body,
+  # every route below is a standalone resource and the AutoDeploy stage serves them all.
   HttpApi:
-    Type: AWS::Serverless::HttpApi
+    Type: AWS::ApiGatewayV2::Api
     Properties:
+      Name: !Ref AWS::StackName
+      ProtocolType: HTTP
+
+  # $default stage = no stage suffix on the URL. AutoDeploy redeploys on any route/integration change.
+  # DependsOn the routes so they exist before the stage — otherwise the first auto-deployment can race
+  # ahead of them and ship an empty route set on initial create.
+  HttpApiStage:
+    Type: AWS::ApiGatewayV2::Stage
+    DependsOn:
+      - BackendApiRoute
+      - FrontendSiteRootRoute
+      - FrontendSiteProxyRoute
+      - AdminAssetsRoute
+    Properties:
+      ApiId: !Ref HttpApi
       StageName: $default
+      AutoDeploy: true
 
   # backend-api owns the JSON API surface: everything under /api/* (health, setup, auth, authoring,
   # blog discovery). The admin SPA is served from S3 under /admin/* (below), so the API sits on /api/*
@@ -127,13 +146,30 @@ Resources:
             TableName: !Ref Table
         - S3CrudPolicy:
             BucketName: !Ref ContentBucket
-      Events:
-        Api:
-          Type: HttpApi
-          Properties:
-            ApiId: !Ref HttpApi
-            Path: /api/{proxy+}
-            Method: ANY
+
+  BackendApiIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt BackendApiFunction.Arn
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  BackendApiRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: 'ANY /api/{proxy+}'
+      Target: !Sub 'integrations/${BackendApiIntegration}'
+
+  BackendApiPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BackendApiFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*/*'
 
   # frontend-site: Hono SSR of the active theme (via @thatblog/renderer + the S3 theme loader). Resolves
   # the blog from the incoming Host (PLAN.md section 10) and serves the public pages, so it takes the
@@ -149,19 +185,40 @@ Resources:
             TableName: !Ref Table
         - S3ReadPolicy:
             BucketName: !Ref ContentBucket
-      Events:
-        Root:
-          Type: HttpApi
-          Properties:
-            ApiId: !Ref HttpApi
-            Path: /
-            Method: ANY
-        Proxy:
-          Type: HttpApi
-          Properties:
-            ApiId: !Ref HttpApi
-            Path: /{proxy+}
-            Method: ANY
+
+  FrontendSiteIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt FrontendSiteFunction.Arn
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  # Root + catch-all: the public site owns everything not matched by the more-specific /api and /admin
+  # routes (HTTP API picks the most specific match). Bare /admin lands here too — no segment for the
+  # /admin/{proxy+} S3 route's greedy var — and frontend-site serves the SPA's index.html inline.
+  FrontendSiteRootRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: 'ANY /'
+      Target: !Sub 'integrations/${FrontendSiteIntegration}'
+
+  FrontendSiteProxyRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: 'ANY /{proxy+}'
+      Target: !Sub 'integrations/${FrontendSiteIntegration}'
+
+  FrontendSitePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref FrontendSiteFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*/*'
 
   # The admin SPA is static assets, so /admin/* is an HTTP-proxy integration straight to the content
   # bucket's public static-website endpoint — no Lambda in the asset path (plan #17). The greedy route

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -21,7 +21,7 @@ Resources:
   Table:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: thatblog
+      TableName: !Ref AWS::StackName
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - { AttributeName: pk, AttributeType: S }
@@ -119,7 +119,7 @@ Resources:
   BackendApiFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-backend-api'
+      FunctionName: !Sub '${AWS::StackName}-api'
       CodeUri: dist/backend-api
       Handler: lambda.handler
       Policies:
@@ -141,7 +141,7 @@ Resources:
   FrontendSiteFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-frontend-site'
+      FunctionName: !Sub '${AWS::StackName}-site'
       CodeUri: dist/frontend-site
       Handler: lambda.handler
       Policies:
@@ -210,12 +210,12 @@ Outputs:
   AdminUrl:
     Description: Admin SPA URL
     Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/admin'
-  TableName:
-    Description: DynamoDB table name
-    Value: !Ref Table
   ContentBucketName:
     Description: Content bucket name (deploy script syncs assets here)
     Value: !Ref ContentBucket
   ContentBucketWebsiteUrl:
     Description: Content bucket static-website endpoint
     Value: !GetAtt ContentBucket.WebsiteURL
+  DynamoTableName:
+    Description: DynamoDB table name
+    Value: !Ref Table

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -164,10 +164,11 @@ Resources:
             Method: ANY
 
   # The admin SPA is static assets, so /admin/* is an HTTP-proxy integration straight to the content
-  # bucket's public static-website endpoint — no Lambda in the asset path (plan #17). Two integrations
-  # because their target URIs differ: the greedy route forwards the captured path via the {proxy}
-  # URI path variable (bare braces, matched by name to the route's {proxy+} — HTTP API syntax, not
-  # ${request.path.proxy}); bare /admin has no path var so it points straight at admin/index.html.
+  # bucket's public static-website endpoint — no Lambda in the asset path (plan #17). The greedy route
+  # forwards the captured path via the {proxy} URI path variable (bare braces, matched by name to the
+  # route's {proxy+} — HTTP API syntax, not ${request.path.proxy}). A bare /admin has no path segment
+  # for {proxy+} to catch, so it falls through to /{proxy+} → frontend-site, which redirects it to the
+  # SPA entrypoint (see components/frontend-site/app.ts).
   AdminAssetsIntegration:
     Type: AWS::ApiGatewayV2::Integration
     Properties:
@@ -177,28 +178,12 @@ Resources:
       IntegrationUri: !Sub 'http://${ContentBucket}.s3-website-${AWS::Region}.amazonaws.com/admin/{proxy}'
       PayloadFormatVersion: '1.0'
 
-  AdminRootIntegration:
-    Type: AWS::ApiGatewayV2::Integration
-    Properties:
-      ApiId: !Ref HttpApi
-      IntegrationType: HTTP_PROXY
-      IntegrationMethod: GET
-      IntegrationUri: !Sub 'http://${ContentBucket}.s3-website-${AWS::Region}.amazonaws.com/admin/index.html'
-      PayloadFormatVersion: '1.0'
-
   AdminAssetsRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref HttpApi
       RouteKey: 'GET /admin/{proxy+}'
       Target: !Sub 'integrations/${AdminAssetsIntegration}'
-
-  AdminRootRoute:
-    Type: AWS::ApiGatewayV2::Route
-    Properties:
-      ApiId: !Ref HttpApi
-      RouteKey: 'GET /admin'
-      Target: !Sub 'integrations/${AdminRootIntegration}'
 
 Outputs:
   Url:

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -21,7 +21,7 @@ Resources:
   Table:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub '${AWS::StackName}-table'
+      TableName: thatblog
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - { AttributeName: pk, AttributeType: S }
@@ -112,10 +112,10 @@ Resources:
     Properties:
       StageName: $default
 
-  # backend-api owns the JSON API surface: /health + everything under /api/* (setup, auth, authoring,
+  # backend-api owns the JSON API surface: everything under /api/* (health, setup, auth, authoring,
   # blog discovery). The admin SPA is served from S3 under /admin/* (below), so the API sits on /api/*
   # to stay clear of it. It's off the catch-all — the public site owns /{proxy+}. HTTP API routes the
-  # most specific match, so /api/{proxy+} and the exact /health both beat the site's /{proxy+}.
+  # most specific match, so /api/{proxy+} beats the site's /{proxy+}.
   BackendApiFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -128,12 +128,6 @@ Resources:
         - S3CrudPolicy:
             BucketName: !Ref ContentBucket
       Events:
-        Health:
-          Type: HttpApi
-          Properties:
-            ApiId: !Ref HttpApi
-            Path: /health
-            Method: ANY
         Api:
           Type: HttpApi
           Properties:
@@ -207,9 +201,12 @@ Resources:
       Target: !Sub 'integrations/${AdminRootIntegration}'
 
 Outputs:
-  ApiUrl:
-    Description: HTTP API base URL
+  Url:
+    Description: API Gateway base URL
     Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com'
+  ApiUrl:
+    Description: JSON API base URL (the /api surface)
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/api'
   AdminUrl:
     Description: Admin SPA URL
     Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/admin'

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: thatblog - multi-tenant serverless blog platform (0.0.5 public site)
+Description: thatblog - multi-tenant serverless blog platform (0.0.6 admin SPA)
 
 Globals:
   Function:
@@ -112,9 +112,10 @@ Resources:
     Properties:
       StageName: $default
 
-  # backend-api owns the JSON API surfaces: /health, /auth/*, /admin/* (setup, authoring; later the
-  # admin SPA). It no longer sits on the catch-all — the public site does. HTTP API routes the most
-  # specific match, so /admin/{proxy+} beats the site's /{proxy+} and /health beats it as an exact key.
+  # backend-api owns the JSON API surface: /health + everything under /api/* (setup, auth, authoring,
+  # blog discovery). The admin SPA is served from S3 under /admin/* (below), so the API sits on /api/*
+  # to stay clear of it. It's off the catch-all — the public site owns /{proxy+}. HTTP API routes the
+  # most specific match, so /api/{proxy+} and the exact /health both beat the site's /{proxy+}.
   BackendApiFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -133,17 +134,11 @@ Resources:
             ApiId: !Ref HttpApi
             Path: /health
             Method: ANY
-        Auth:
+        Api:
           Type: HttpApi
           Properties:
             ApiId: !Ref HttpApi
-            Path: /auth/{proxy+}
-            Method: ANY
-        Admin:
-          Type: HttpApi
-          Properties:
-            ApiId: !Ref HttpApi
-            Path: /admin/{proxy+}
+            Path: /api/{proxy+}
             Method: ANY
 
   # frontend-site: Hono SSR of the active theme (via @thatblog/renderer + the S3 theme loader). Resolves
@@ -174,10 +169,49 @@ Resources:
             Path: /{proxy+}
             Method: ANY
 
+  # The admin SPA is static assets, so /admin/* is an HTTP-proxy integration straight to the content
+  # bucket's public static-website endpoint — no Lambda in the asset path (plan #17). Two integrations
+  # because their target URIs differ: the greedy route forwards the captured {proxy} path, while bare
+  # /admin has no path var so it points straight at admin/index.html (the SPA entrypoint).
+  AdminAssetsIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: GET
+      IntegrationUri: !Sub 'http://${ContentBucket}.s3-website-${AWS::Region}.amazonaws.com/admin/${!request.path.proxy}'
+      PayloadFormatVersion: '1.0'
+
+  AdminRootIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: GET
+      IntegrationUri: !Sub 'http://${ContentBucket}.s3-website-${AWS::Region}.amazonaws.com/admin/index.html'
+      PayloadFormatVersion: '1.0'
+
+  AdminAssetsRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: 'GET /admin/{proxy+}'
+      Target: !Sub 'integrations/${AdminAssetsIntegration}'
+
+  AdminRootRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: 'GET /admin'
+      Target: !Sub 'integrations/${AdminRootIntegration}'
+
 Outputs:
   ApiUrl:
     Description: HTTP API base URL
     Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com'
+  AdminUrl:
+    Description: Admin SPA URL
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/admin'
   TableName:
     Description: DynamoDB table name
     Value: !Ref Table

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "thatblog",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "workspaces": ["components/*", "packages/*", "themes/*"],
   "scripts": {
-    "build": "bun run build:api && bun run build:site",
+    "build": "bun run build:api && bun run build:site && bun run build:admin",
     "build:api": "bun build ./components/backend-api/lambda.ts --target=node --format=cjs --outdir=infra/dist/backend-api --sourcemap=linked",
     "build:site": "bun build ./components/frontend-site/lambda.ts --target=node --format=cjs --outdir=infra/dist/frontend-site --sourcemap=linked",
+    "build:admin": "bun run --cwd components/frontend-admin build",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["components/**/*.ts", "packages/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+  "include": ["components/**/*.ts", "packages/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
+  "exclude": ["**/node_modules", "**/dist", "components/frontend-admin"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['**/*.spec.ts'],
+    // The model singletons build from client.ts at import time, which asserts TABLE_NAME is set.
+    // Tests don't use those singletons (they inject a Testcontainers table via makeModels), but the
+    // import still evaluates, so a value must be present. The real table name comes from inject().
+    env: { TABLE_NAME: 'thatblog-test' },
     globalSetup: ['./test/global-setup.ts'],
     testTimeout: 30_000,
     hookTimeout: 30_000,


### PR DESCRIPTION
## v0.0.6 — Admin SPA

Adds a minimal React + Vite admin SPA served under `/admin`, and moves the JSON API onto `/api/*` so the S3-served SPA can own `/admin/*` cleanly. Closes out the `0.0.x` MVP spine (deploy → setup → log in → compose → publish → see it live).

### Routing decision
`/admin/*` serves the SPA's static assets from S3; the JSON API moved wholesale to **`/api/*`** to stay clear of it (no most-specific-match co-existence). HTTP API routes:

| Route | Target |
|---|---|
| `/api/{proxy+}` | backend-api Lambda (health, setup, auth, authoring, blog discovery) |
| `/admin/{proxy+}` | S3 website endpoint (HTTP_PROXY) — the SPA's hashed assets |
| `/admin` (bare) | falls through to `/{proxy+}` → frontend-site, which serves `admin/index.html` inline |
| `/`, `/{proxy+}` | frontend-site (public SSR) |

### Backend
- Renamed routes: `/api/health`, `/api/setup/:key`, `/api/auth/{login,me,logout}`, `/api/blogs/:blogId/posts/*`
- New `GET /api/blogs` — blog discovery for the SPA (`MapBlogUser.byUser` hydrate for the role + `Blog.get` BatchGet for names; confirmed `hydrate: true` works on the gs1 KEYS_ONLY index)
- `client.ts` now **requires** `TABLE_NAME` (asserts, no default) so a misconfigured Lambda fails fast

### Frontend — `@thatblog/frontend-admin`
- React 19 + Vite 6 (`base: '/admin/'`), conditional-render auth gate (no router lib)
- Login → Dashboard: 300-char short-post composer (Save draft / Publish = create-then-publish) + recent-posts list

### frontend-site
- Serves the SPA's `admin/index.html` inline at bare `/admin` (reads it from the content bucket via `s3Loader`), ahead of host resolution since the admin build is global. Keeps `/admin` a clean URL; assets load from S3 via `/admin/{proxy+}`.

### Infra
- backend-api events → `/api/{proxy+}`; table name = stack name; functions `${StackName}-api` / `-site`
- HTTP_PROXY integration to the S3 website endpoint for `/admin/{proxy+}` (path var is bare `{proxy}`, matched to the route's `{proxy+}` — **not** `${request.path.proxy}`, which fails at deploy)
- Outputs: `Url` (API Gateway base), `ApiUrl` (`…/api`), `AdminUrl` (`…/admin`), `DynamoTableName`
- `build:admin` in the root build; `deploy.sh` syncs `frontend-admin/dist/` → `s3://…/admin/` and health-checks `/api/health`

### Validation
- ✅ 58 unit tests, root + SPA typechecks, full `bun run build` (both Lambdas + SPA)

### Deploy note
⚠️ First stack deploy after 0.0.5 hit two issues since fixed: the S3 integration path-var syntax, and the table rename (`TableName` is a *replacement* property — renaming drops the old table). Fresh deploys are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)